### PR TITLE
Fix for combine PRs action

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -34,7 +34,7 @@ jobs:
         id: create-combined-pr
         name: Create Combined PR
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
           script: |
             const pulls = await github.paginate('GET /repos/:owner/:repo/pulls', {
               owner: context.repo.owner,


### PR DESCRIPTION
Updated to the latest action from https://github.com/hrvey/combine-prs-workflow, but updated the code to work with repos that use GH Actions for CI checks (credit goes to the PR https://github.com/hrvey/combine-prs-workflow/pull/6)