### PR TITLE
Update linter + fixes

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: v1.17
+          go-version: v1.19
       - name: Checkout
         uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test API
     strategy:
       matrix:
-        go-version: [v1.17.x, v1.18.x]
+        go-version: [1.18.x, v1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,36 @@
 linters-settings:
+  revive:
+    ignore-generated-header: false
+    severity: warning
+    confidence: 0.8
+    errorCode: 0
+    warningCode: 0
+    rules:
+      - name:  blank-imports
+      - name:  context-as-argument
+      - name:  context-keys-type
+      - name:  dot-imports
+      - name:  error-return
+      - name:  error-strings
+      - name:  error-naming
+      - name:  exported
+      - name:  if-return
+      - name:  increment-decrement
+      - name:  var-naming
+      - name:  var-declaration
+      - name:  package-comments
+        disabled: true
+      - name:  range
+      - name:  receiver-naming
+      - name:  time-naming
+      - name:  unexported-return
+      - name:  indent-error-flow
+      - name:  errorf
+      - name:  empty-block
+      - name:  superfluous-else
+      - name:  unused-parameter
+      - name:  unreachable-code
+      - name:  redefines-builtin-id
   misspell:
     locale: US
 

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,5 @@ test:
 # Lint
 
 lint:
-	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 run
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.49.0 run
 .PHONYY: lint

--- a/cmd/rigs/cmd/local_inventory.go
+++ b/cmd/rigs/cmd/local_inventory.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path"
@@ -32,13 +31,13 @@ var inventoryCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 		checkErr(localStore.Reset(ctx))
-		checkErr(processRootNode(ctx, viper.GetString("layers-path")))
+		checkErr(processRootNode(viper.GetString("layers-path")))
 		checkErr(localStore.InsertParts(ctx, parts))
 		checkErr(localStore.InsertLayers(ctx, layers))
 	},
 }
 
-func processRootNode(ctx context.Context, rootPath string) error {
+func processRootNode(rootPath string) error {
 	entries, err := os.ReadDir(rootPath)
 	if err != nil {
 		return err
@@ -54,7 +53,7 @@ func processRootNode(ctx context.Context, rootPath string) error {
 			Name: fleetName,
 		})
 
-		if err := processFleetNode(ctx, fleetName, rootPath, e.Name()); err != nil {
+		if err := processFleetNode(fleetName, rootPath, e.Name()); err != nil {
 			return fmt.Errorf("processing fleet node: %v", err)
 		}
 	}
@@ -62,7 +61,6 @@ func processRootNode(ctx context.Context, rootPath string) error {
 }
 
 func processFleetNode(
-	ctx context.Context,
 	fleetName string,
 	rootPath string,
 	relativePath string,

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -620,7 +620,7 @@ func (b *Builder) AssembleImage(
 	defer r.Dispose()
 
 	for _, l := range layers {
-		i, err := getLayer(ctx, layersPath, l.Path)
+		i, err := getLayer(layersPath, l.Path)
 		if err != nil {
 			return fmt.Errorf("getting layer: %v", err)
 		}
@@ -795,10 +795,7 @@ func resizeImage(data io.Reader, size image.Rectangle, to io.Writer) error {
 	}
 	dst := image.NewRGBA(size)
 	draw.CatmullRom.Scale(dst, size, i, i.Bounds(), draw.Over, nil)
-	if err := png.Encode(to, dst); err != nil {
-		return err
-	}
-	return nil
+	return png.Encode(to, dst)
 }
 
 func (b *Builder) fleets(ctx context.Context) ([]local.Part, error) {
@@ -860,7 +857,7 @@ func (b *Builder) fleetPartTypeParts(ctx context.Context, fleet string, partType
 	return parts, nil
 }
 
-func getLayer(ctx context.Context, layersPath, imagePath string) (image.Image, error) {
+func getLayer(layersPath, imagePath string) (image.Image, error) {
 	f, err := os.Open(path.Join(layersPath, imagePath))
 	if err != nil {
 		return nil, err

--- a/pkg/dirpublisher/dirpublisher.go
+++ b/pkg/dirpublisher/dirpublisher.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -131,7 +130,7 @@ L0:
 			return "", fmt.Errorf("iterating splitter: %v", err)
 		}
 		log.Default().Printf("writing car chunk %d\n", c)
-		b, err := ioutil.ReadAll(car)
+		b, err := io.ReadAll(car)
 		if err != nil {
 			return "", fmt.Errorf("reading car chunk: %v", err)
 		}

--- a/pkg/nftstorage/client.go
+++ b/pkg/nftstorage/client.go
@@ -45,6 +45,7 @@ func (c *Client) UploadCar(ctx context.Context, payload io.Reader) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("creating request: %v", err)
 	}
+	req = req.WithContext(ctx)
 	c.setAuthHeader(req)
 	req.Header.Set("Content-Type", "application/car")
 

--- a/pkg/storage/local/impl/store.go
+++ b/pkg/storage/local/impl/store.go
@@ -161,14 +161,14 @@ func (s *Store) InsertRigs(ctx context.Context, rigs []local.Rig) error {
 		Vals(partVals...).
 		Executor()
 
-	if _, err = insertRigs.Exec(); err != nil {
+	if _, err = insertRigs.ExecContext(ctx); err != nil {
 		if rErr := tx.Rollback(); rErr != nil {
 			return fmt.Errorf("rolling back tx: %v, inserting rigs: %v", rErr, err)
 		}
 		return fmt.Errorf("inserting rigs: %v", err)
 	}
 
-	if _, err = insertParts.Exec(); err != nil {
+	if _, err = insertParts.ExecContext(ctx); err != nil {
 		if rErr := tx.Rollback(); rErr != nil {
 			return fmt.Errorf("rolling back tx: %v, inserting parts: %v", rErr, err)
 		}
@@ -420,7 +420,7 @@ func (s *Store) Counts(ctx context.Context) (local.Counts, error) {
 		)
 	`
 	var counts local.Counts
-	if _, err := s.db.ScanStruct(&counts, q); err != nil {
+	if _, err := s.db.ScanStructContext(ctx, &counts, q); err != nil {
 		return local.Counts{}, fmt.Errorf("scanning structs: %v", err)
 	}
 	return counts, nil
@@ -446,7 +446,7 @@ func (s *Store) FleetRankings(ctx context.Context) ([]local.Ranking, error) {
 		order by percentage
 	`
 	var rankings []local.Ranking
-	if err := s.db.ScanStructs(&rankings, q); err != nil {
+	if err := s.db.ScanStructsContext(ctx, &rankings, q); err != nil {
 		return nil, fmt.Errorf("scanning structs: %v", err)
 	}
 	return rankings, nil
@@ -471,7 +471,7 @@ func (s *Store) BackgroundColorRankings(ctx context.Context) ([]local.Ranking, e
 	order by percentage
 	`
 	var rankings []local.Ranking
-	if err := s.db.ScanStructs(&rankings, q); err != nil {
+	if err := s.db.ScanStructsContext(ctx, &rankings, q); err != nil {
 		return nil, fmt.Errorf("scanning structs: %v", err)
 	}
 	return rankings, nil
@@ -496,7 +496,7 @@ func (s *Store) OriginalRankings(ctx context.Context, fleet string) ([]local.Ran
 		order by percentage
 	`
 	var rankings []local.Ranking
-	if err := s.db.ScanStructs(&rankings, q, fleet, fleet); err != nil {
+	if err := s.db.ScanStructsContext(ctx, &rankings, q, fleet, fleet); err != nil {
 		return nil, fmt.Errorf("scanning structs: %v", err)
 	}
 	return rankings, nil

--- a/pkg/storage/tableland/impl/files/store.go
+++ b/pkg/storage/tableland/impl/files/store.go
@@ -46,7 +46,7 @@ func NewStore(c Config) (tableland.Store, error) {
 }
 
 // CreateTable implements CreateTable.
-func (s *Store) CreateTable(ctx context.Context, definition tableland.TableDefinition) (string, error) {
+func (s *Store) CreateTable(_ context.Context, _ tableland.TableDefinition) (string, error) {
 	return "", errors.New("CreateTable not implemented")
 }
 
@@ -60,7 +60,7 @@ func (s *Store) InsertParts(ctx context.Context, parts []local.Part) error {
 	if err != nil {
 		return fmt.Errorf("getting sql to insert parts: %v", err)
 	}
-	return s.writeSQL(ctx, "parts", sql)
+	return s.writeSQL("parts", sql)
 }
 
 // InsertLayers implements InsertLayers.
@@ -73,7 +73,7 @@ func (s *Store) InsertLayers(ctx context.Context, cid string, layers []local.Lay
 	if err != nil {
 		return fmt.Errorf("getting sql to insert layers: %v", err)
 	}
-	return s.writeSQL(ctx, "layers", sql)
+	return s.writeSQL("layers", sql)
 }
 
 // InsertRigs implements InsertRigs.
@@ -86,7 +86,7 @@ func (s *Store) InsertRigs(ctx context.Context, cid string, rigs []local.Rig) er
 	if err != nil {
 		return fmt.Errorf("getting sql to insert rigs: %v", err)
 	}
-	return s.writeSQL(ctx, "rigs", sql)
+	return s.writeSQL("rigs", sql)
 }
 
 // InsertRigAttributes implements InsertRigAttributes.
@@ -99,26 +99,26 @@ func (s *Store) InsertRigAttributes(ctx context.Context, rigs []local.Rig) error
 	if err != nil {
 		return fmt.Errorf("getting sql to insert rig attributes: %v", err)
 	}
-	return s.writeSQL(ctx, "rig-attributes", sql)
+	return s.writeSQL("rig-attributes", sql)
 }
 
 // ClearPartsData implements ClearPartsData.
-func (s *Store) ClearPartsData(ctx context.Context) error {
+func (s *Store) ClearPartsData(_ context.Context) error {
 	return errors.New("ClearPartsData not implemented")
 }
 
 // ClearLayersData implements ClearLayersData.
-func (s *Store) ClearLayersData(ctx context.Context) error {
+func (s *Store) ClearLayersData(_ context.Context) error {
 	return errors.New("ClearLayersData not implemented")
 }
 
 // ClearRigsData implements ClearRigsData.
-func (s *Store) ClearRigsData(ctx context.Context) error {
+func (s *Store) ClearRigsData(_ context.Context) error {
 	return errors.New("ClearRigsData not implemented")
 }
 
 // ClearRigAttributesData implements ClearRigAttributesData.
-func (s *Store) ClearRigAttributesData(ctx context.Context) error {
+func (s *Store) ClearRigAttributesData(_ context.Context) error {
 	return errors.New("ClearRigAttributesData not implemented")
 }
 
@@ -127,7 +127,7 @@ func (s *Store) Close() error {
 	return nil
 }
 
-func (s *Store) writeSQL(ctx context.Context, category, sql string) error {
+func (s *Store) writeSQL(category, sql string) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 

--- a/pkg/storage/tableland/impl/sqlite/store.go
+++ b/pkg/storage/tableland/impl/sqlite/store.go
@@ -31,11 +31,11 @@ func NewStore(db *sql.DB) (tableland.Store, error) {
 // CreateTable implements CreateTable.
 func (s *Store) CreateTable(ctx context.Context, definition tableland.TableDefinition) (string, error) {
 	drop := fmt.Sprintf("drop table if exists %s", definition.Prefix)
-	if _, err := s.db.Exec(drop); err != nil {
+	if _, err := s.db.ExecContext(ctx, drop); err != nil {
 		return "", fmt.Errorf("dropping table: %v", err)
 	}
 	statement := fmt.Sprintf("create table %s %s strict", definition.Prefix, definition.Schema)
-	if _, err := s.db.Exec(statement); err != nil {
+	if _, err := s.db.ExecContext(ctx, statement); err != nil {
 		return "", fmt.Errorf("creating table: %v", err)
 	}
 	return definition.Prefix, nil


### PR DESCRIPTION
Spent some time yesterday getting `golangci-lint` updated and setting the recommended rules for the `revive` linter. It worked well, so moved the same setting in this repo.