### PR TITLE
consistent go version name

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: v1.19
+          go-version: 1.19
       - name: Checkout
         uses: actions/checkout@v2
       - uses: actions/cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Test API
     strategy:
       matrix:
-        go-version: [1.18.x, v1.19.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Things were getting confusing with the check names being inconsistent. 