### PR TITLE
Run npm install for viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Now that we've built our Rigs data and imagery locally, we're ready to publish t
 We'll first push the Rigs images to NFT.storage.
 
 ```
-> rigs publish images
+> rigs publish renders
 2022/08/24 20:50:00 Adding folder to IPFS...
 
 ...

--- a/cmd/rigs/cmd/local_view.go
+++ b/cmd/rigs/cmd/local_view.go
@@ -41,11 +41,18 @@ var viewCmd = &cobra.Command{
 		if !viper.GetBool("no-viewer") {
 			r.PathPrefix("/").Handler(http.FileServer(http.Dir("viewer/dist")))
 			checkErr(os.Setenv("API", api))
-			npmCmd := exec.Command("npm", "run", "generate")
-			npmCmd.Dir = "viewer"
-			stdout, err := npmCmd.Output()
+
+			installCmd := exec.Command("npm", "install")
+			installCmd.Dir = "viewer"
+			installOut, err := installCmd.Output()
 			checkErr(err)
-			fmt.Println(string(stdout))
+			fmt.Println(string(installOut))
+
+			runCmd := exec.Command("npm", "run", "generate")
+			runCmd.Dir = "viewer"
+			runOut, err := runCmd.Output()
+			checkErr(err)
+			fmt.Println(string(runOut))
 		}
 
 		go func() {


### PR DESCRIPTION
If you didn't manually run `npm install` before, you'd get an error when running `rigs local view`. This runs it for you.