### PR TITLE
Fix SIWE implementation

### DIFF
--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.1",
+        "siwe": "^2.1.3",
         "wagmi": "^0.6.7"
       },
       "devDependencies": {
@@ -4047,6 +4048,17 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@pedrouid/environment": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
@@ -5237,16 +5249,14 @@
       }
     },
     "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.0.tgz",
-      "integrity": "sha512-zXlPBRKaT9ecxhhLQqn/StAWlXvQBlFDFnIAlM7ceMVx/1NVZZ65GdW9A28tYGbhpesYxNYpsqegGsBcrWuASg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
       "dependencies": {
+        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
-      },
-      "peerDependencies": {
-        "keccak": "^3.0.2"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -13672,11 +13682,11 @@
       "peer": true
     },
     "node_modules/siwe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.0.5.tgz",
-      "integrity": "sha512-PZku0+V915YvzVuProsC+RD6unKBo3208X/+t9ARk1WHjYMbtGnxuyBuMASdmLFI3nqJiorko5qrT0ihCFwlHQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
       "dependencies": {
-        "@spruceid/siwe-parser": "2.0.0",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -17991,6 +18001,11 @@
         "tslib": "^2.3.1"
       }
     },
+    "@noble/hashes": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
+    },
     "@pedrouid/environment": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
@@ -18903,10 +18918,11 @@
       }
     },
     "@spruceid/siwe-parser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.0.tgz",
-      "integrity": "sha512-zXlPBRKaT9ecxhhLQqn/StAWlXvQBlFDFnIAlM7ceMVx/1NVZZ65GdW9A28tYGbhpesYxNYpsqegGsBcrWuASg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
+      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
       "requires": {
+        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -25423,11 +25439,11 @@
       "peer": true
     },
     "siwe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.0.5.tgz",
-      "integrity": "sha512-PZku0+V915YvzVuProsC+RD6unKBo3208X/+t9ARk1WHjYMbtGnxuyBuMASdmLFI3nqJiorko5qrT0ihCFwlHQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
+      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
       "requires": {
-        "@spruceid/siwe-parser": "2.0.0",
+        "@spruceid/siwe-parser": "^2.0.2",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"

--- a/garage/package.json
+++ b/garage/package.json
@@ -21,6 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.1",
+    "siwe": "^2.1.3",
     "wagmi": "^0.6.7"
   },
   "devDependencies": {

--- a/garage/src/App.tsx
+++ b/garage/src/App.tsx
@@ -16,6 +16,7 @@ import { configureChains, createClient, WagmiConfig } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 import { Topbar } from "./Topbar";
+import { RainbowKitTablelandSiweProvider } from "./components/RainbowKitTablelandSiweProvider";
 import { RequiresWalletConnection } from "./components/RequiresWalletConnection";
 import { routes } from "./routes";
 import { chain } from "./env";
@@ -170,30 +171,32 @@ function App() {
   return (
     <ChakraProvider theme={theme}>
       <WagmiConfig client={wagmiClient}>
-        <RainbowKitProvider chains={chains} theme={darkTheme()}>
-          <BrowserRouter>
-            <Topbar />
-            <Routes>
-              {routes().map(
-                ({ requiresWalletConnection, element, ...props }, index) => (
-                  <Route
-                    {...props}
-                    key={`route-${index}`}
-                    element={
-                      requiresWalletConnection ? (
-                        <RequiresWalletConnection>
-                          {element}
-                        </RequiresWalletConnection>
-                      ) : (
-                        element
-                      )
-                    }
-                  />
-                )
-              )}
-            </Routes>
-          </BrowserRouter>
-        </RainbowKitProvider>
+        <RainbowKitTablelandSiweProvider>
+          <RainbowKitProvider chains={chains} theme={darkTheme()}>
+            <BrowserRouter>
+              <Topbar />
+              <Routes>
+                {routes().map(
+                  ({ requiresWalletConnection, element, ...props }, index) => (
+                    <Route
+                      {...props}
+                      key={`route-${index}`}
+                      element={
+                        requiresWalletConnection ? (
+                          <RequiresWalletConnection>
+                            {element}
+                          </RequiresWalletConnection>
+                        ) : (
+                          element
+                        )
+                      }
+                    />
+                  )
+                )}
+              </Routes>
+            </BrowserRouter>
+          </RainbowKitProvider>
+        </RainbowKitTablelandSiweProvider>
       </WagmiConfig>
     </ChakraProvider>
   );

--- a/garage/src/components/RainbowKitTablelandSiweProvider.tsx
+++ b/garage/src/components/RainbowKitTablelandSiweProvider.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo, useState } from "react";
+import { SiweMessage, generateNonce } from "siwe";
+import {
+  createAuthenticationAdapter,
+  RainbowKitAuthenticationProvider,
+  AuthenticationStatus,
+} from "@rainbow-me/rainbowkit";
+import { connection } from "../hooks/useTablelandConnection";
+
+interface RainbowKitSiweNextAuthProviderProps {
+  children: React.ReactNode;
+}
+
+export const RainbowKitTablelandSiweProvider = ({
+  children,
+}: RainbowKitSiweNextAuthProviderProps) => {
+  const [status, setStatus] = useState<AuthenticationStatus>("unauthenticated");
+  const adapter = useMemo(
+    () =>
+      createAuthenticationAdapter({
+        getNonce: async () => {
+          return generateNonce();
+        },
+
+        createMessage: ({ nonce, address, chainId }) => {
+          const issuedAt = new Date().toISOString();
+          const now = Date.now();
+          const expirationTime = new Date(
+            now + 10 * 60 * 60 * 1000
+          ).toISOString(); // Default to ~10 hours
+
+          return new SiweMessage({
+            domain: "Tableland",
+            address,
+            statement: "Official Tableland SDK",
+            uri: window.location.origin,
+            version: "1",
+            chainId,
+            nonce,
+            issuedAt,
+            expirationTime,
+          });
+        },
+
+        getMessageBody: ({ message }) => {
+          return message.prepareMessage();
+        },
+
+        verify: async ({ message, signature }) => {
+          const token = window.btoa(
+            JSON.stringify({
+              message: message.toMessage(),
+              signature,
+            })
+          );
+          connection.token = { token };
+
+          setStatus("authenticated");
+
+          return true;
+        },
+
+        signOut: async () => {},
+      }),
+    [setStatus]
+  );
+
+  return (
+    <RainbowKitAuthenticationProvider adapter={adapter} status={status}>
+      {children}
+    </RainbowKitAuthenticationProvider>
+  );
+};

--- a/garage/src/components/TablelandConnectButton.tsx
+++ b/garage/src/components/TablelandConnectButton.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import {
   Button,
   Flex,
@@ -7,7 +7,6 @@ import {
   useBreakpointValue,
 } from "@chakra-ui/react";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
-import { useTablelandConnection } from "../hooks/useTablelandConnection";
 import exit from "../assets/exit.svg";
 
 export const TablelandConnectButton = ({
@@ -19,7 +18,6 @@ export const TablelandConnectButton = ({
     { base: false, sm: true },
     { ssr: false }
   );
-  const { connection: tableland } = useTablelandConnection();
 
   return (
     <ConnectButton.Custom>
@@ -29,21 +27,15 @@ export const TablelandConnectButton = ({
         openAccountModal,
         openChainModal,
         openConnectModal,
+        authenticationStatus,
         mounted,
       }) => {
-        const connected = mounted && account && chain && tableland.token;
-
-        const connect = useCallback(() => {
-          if (!mounted) return;
-
-          if (!account || !chain) {
-            openConnectModal();
-          }
-
-          if (account && chain) {
-            tableland.siwe();
-          }
-        }, [mounted, account, chain, tableland]);
+        const ready = mounted && authenticationStatus !== "loading";
+        const connected =
+          ready &&
+          account &&
+          chain &&
+          (!authenticationStatus || authenticationStatus === "authenticated");
 
         return (
           <div
@@ -60,7 +52,7 @@ export const TablelandConnectButton = ({
               if (!connected) {
                 return (
                   <Button
-                    onClick={connect}
+                    onClick={openConnectModal}
                     variant="connect"
                     borderRadius="3px"
                     sx={{

--- a/garage/src/hooks/useTablelandConnection.ts
+++ b/garage/src/hooks/useTablelandConnection.ts
@@ -5,7 +5,7 @@ const chain = Object.entries(SUPPORTED_CHAINS).find(
   ([_, chain]) => chain.chainId === envChain.id
 )![0] as ChainName;
 
-const connection = connect({
+export const connection = connect({
   network: "testnet",
   chain,
 });


### PR DESCRIPTION
Replaces the hacky use of the tableland sdk siwe call in the connect button with a proper `RainbowKitAuthenticationProvider`.

Related, we should maybe look at refactoring the SDK code so that we can re-use the code for auth implementations like this? I had to copy/paste the code we use in the sdk to create the message since we don't expose that code.