### PR TITLE
Use single source of truth for deployment tables

### DIFF
--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -1,8 +1,23 @@
 <script>
   /** @type {import('./$types').PageData} */
   export let data;
-
 </script>
+
+<div class="container">
+  <img class="rig-image" src={data.imageUrl} alt="rig" width="100%" />
+  <div class="badges-container">
+    {#each data.badges as badge}
+      {#if badge}
+        <img src={badge} class="badge" alt="badge" />
+      {:else}
+        <div class="badge" />
+      {/if}
+    {/each}
+  </div>
+  {#if data.pilot}
+    <img class="pilot" src={data.pilot} alt="pilot" />
+  {/if}
+</div>
 
 <style type="text/css">
   :global(body) {
@@ -47,22 +62,4 @@
     border-left: 0.1875rem solid #101e1e;
     border-radius: 0.1875rem 0 0 0;
   }
-
 </style>
-<div class="container">
-  <img class="rig-image" src={ data.imageUrl } alt="rig" width=100%>
-  <div class="badges-container">
-    {#each data.badges as badge }
-    {#if badge}
-    <img src={ badge } class="badge" alt="badge">
-    {:else}
-    <div class="badge"></div>
-    {/if}
-    {/each}
-  </div>
-  {#if data.pilot}
-  <img class="pilot" src={ data.pilot } alt="pilot">
-  {/if}
-</div>
-
-

--- a/animation_url/src/routes/[slug]/+page.ts
+++ b/animation_url/src/routes/[slug]/+page.ts
@@ -5,7 +5,7 @@ const chain = "polygon-mumbai"; // "ethereum"
 
 const attributesTable = deployments[chain].attributesTable;
 const lookupsTable = deployments[chain].lookupsTable;
-const pilotSessionsTable = deployments[chain].sessionsTable;
+const pilotSessionsTable = deployments[chain].pilotSessionsTable;
 const ipfsGatewayUri = "https://nftstorage.link/ipfs/";
 
 /** @type {import('./$types').PageLoad} */
@@ -21,7 +21,7 @@ export async function load({ url }) {
   const stm = `select json_object(
     'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name
   ) from ${attributesTable} join ${lookupsTable} where rig_id=${rigId} group by rig_id;`;
-  const metadata: any = await tableland.read(stm, {
+  const metadata = await tableland.read(stm, {
     output: "objects",
     extract: true,
     unwrap: true,
@@ -30,7 +30,7 @@ export async function load({ url }) {
 
   // get pilot
   let pilot;
-  const sessions: any = await tableland.read(
+  const sessions = await tableland.read(
     `SELECT end_time FROM ${pilotSessionsTable} WHERE rig_id = ${rigId} AND end_time is null;`,
     { output: "objects" }
   );

--- a/animation_url/src/routes/[slug]/+page.ts
+++ b/animation_url/src/routes/[slug]/+page.ts
@@ -1,8 +1,11 @@
 import { connect } from "@tableland/sdk";
+import { deployments } from "deployments";
 
-const attributesTable = "rig_attributes_80001_3507";
-const lookupsTable = "lookups_80001_3508";
-const pilotSessionsTable = "pilot_sessions_80001_3515";
+const chain = "polygon-mumbai"; // "ethereum"
+
+const attributesTable = deployments[chain].attributesTable;
+const lookupsTable = deployments[chain].lookupsTable;
+const pilotSessionsTable = deployments[chain].sessionsTable;
 const ipfsGatewayUri = "https://nftstorage.link/ipfs/";
 
 /** @type {import('./$types').PageLoad} */

--- a/animation_url/tsconfig.json
+++ b/animation_url/tsconfig.json
@@ -9,9 +9,10 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true
-  }
+  },
   // Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias
   //
   // If you want to overwrite includes/excludes, make sure to copy over the relevant includes/excludes
   // from the referenced tsconfig.json - TypeScript does not merge them in
+  "files": ["./../ethereum/deployments.ts"]
 }

--- a/animation_url/vite.config.ts
+++ b/animation_url/vite.config.ts
@@ -1,8 +1,14 @@
+import { resolve } from "node:path";
 import { sveltekit } from "@sveltejs/kit/vite";
 import type { UserConfig } from "vite";
 
 const config: UserConfig = {
   plugins: [sveltekit()],
+  resolve: {
+    alias: {
+      deployments: resolve(__dirname, "..", "ethereum", "deployments.ts"),
+    },
+  },
 };
 
 export default config;


### PR DESCRIPTION
Instead of hard coding the table names, this change will look at the definitions in `ethereum/deployments.ts` for the table definitions.