### PR TITLE
Fix builds, use latest contract deployment & remove badges section with dummy data

### DIFF
--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -21,7 +21,7 @@
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
         "siwe": "^2.1.3",
-        "wagmi": "^0.7.10"
+        "wagmi": "~0.6.7"
       },
       "devDependencies": {
         "@types/react": "^18.0.17",
@@ -159,9 +159,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
-      "integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.2.tgz",
+      "integrity": "sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==",
       "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -169,7 +169,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-member-expression-to-functions": "^7.18.9",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6"
       },
       "engines": {
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -655,16 +655,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.19.4.tgz",
-      "integrity": "sha512-wHmj6LDxVDnL+3WhXteUBaoM1aVILZODAUjg11kHqG4cOlfgMQGxw6aCgvrXrmaJR3Bn14oZhImyCPZzRpC93Q==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.2.tgz",
+      "integrity": "sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.18.8"
+        "@babel/plugin-transform-parameters": "^7.20.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1055,12 +1055,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.0.tgz",
-      "integrity": "sha512-sXOohbpHZSk7GjxK9b3dKB7CfqUD5DwOH+DggKzOQ7TXYP+RCSbRykfjQmn/zq+rBjycVRtLf9pYhAaEJA786w==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.2.tgz",
+      "integrity": "sha512-y5V15+04ry69OV2wULmwhEA6jwSWXO1TwAtIwiPXcvHcoOQUqpyMVd2bDsQJMW8AurjulIyUV8kDqtjSwHy1uQ==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1070,18 +1070,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
-      "integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.2.tgz",
+      "integrity": "sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==",
       "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.20.0",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.19.0",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       },
@@ -1108,12 +1108,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.0.tgz",
-      "integrity": "sha512-1dIhvZfkDVx/zn2S1aFwlruspTt4189j7fEkH0Y0VyuDM6bQt7bD6kLcz3l4IlLG+e5OReaBz9ROAbttRtUHqA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.2.tgz",
+      "integrity": "sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1594,13 +1594,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.0.tgz",
-      "integrity": "sha512-xOAsAFaun3t9hCwZ13Qe7gq423UgMZ6zAgmLxeGGapFqlT/X3L5qT2btjiVLlFn7gWtMaVyceS5VxGAuKbgizw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.2.tgz",
+      "integrity": "sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==",
       "peer": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.19.0",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/helper-create-class-features-plugin": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-typescript": "^7.20.0"
       },
       "engines": {
@@ -1642,18 +1642,18 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.4.tgz",
-      "integrity": "sha512-5QVOTXUdqTCjQuh2GGtdd7YEhoRXBMVGROAtsBeLGIbIz3obCBIfRMT1I3ZKkMgNzwkyCkftDXSSkHxnfVf4qg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "peer": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-validator-option": "^7.18.6",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-        "@babel/plugin-proposal-async-generator-functions": "^7.19.1",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-class-static-block": "^7.18.6",
         "@babel/plugin-proposal-dynamic-import": "^7.18.6",
@@ -1662,7 +1662,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.19.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-proposal-private-methods": "^7.18.6",
@@ -1673,7 +1673,7 @@
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-import-assertions": "^7.18.6",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1686,10 +1686,10 @@
         "@babel/plugin-transform-arrow-functions": "^7.18.6",
         "@babel/plugin-transform-async-to-generator": "^7.18.6",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-        "@babel/plugin-transform-block-scoping": "^7.19.4",
-        "@babel/plugin-transform-classes": "^7.19.0",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
         "@babel/plugin-transform-computed-properties": "^7.18.9",
-        "@babel/plugin-transform-destructuring": "^7.19.4",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
@@ -1697,14 +1697,14 @@
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
-        "@babel/plugin-transform-modules-amd": "^7.18.6",
-        "@babel/plugin-transform-modules-commonjs": "^7.18.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.19.0",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
         "@babel/plugin-transform-new-target": "^7.18.6",
         "@babel/plugin-transform-object-super": "^7.18.6",
-        "@babel/plugin-transform-parameters": "^7.18.8",
+        "@babel/plugin-transform-parameters": "^7.20.1",
         "@babel/plugin-transform-property-literals": "^7.18.6",
         "@babel/plugin-transform-regenerator": "^7.18.6",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
@@ -1716,7 +1716,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.18.10",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.19.4",
+        "@babel/types": "^7.20.2",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
-      "integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -5211,9 +5211,9 @@
       }
     },
     "node_modules/@solana/web3.js/node_modules/react-native": {
-      "version": "0.70.4",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.4.tgz",
-      "integrity": "sha512-1e4jWotS20AJ/4lGVkZQs2wE0PvCpIRmPQEQ1FyH7wdyuewFFIxbUHqy6vAj1JWVFfAzbDakOQofrIkkHWLqNA==",
+      "version": "0.70.5",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.5.tgz",
+      "integrity": "sha512-5NZM80LC3L+TIgQX/09yiyy48S73wMgpIgN5cCv3XTMR394+KpDI3rBZGH4aIgWWuwijz31YYVF5504+9n2Zfw==",
       "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.0.3",
@@ -5731,9 +5731,9 @@
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.6.9.tgz",
-      "integrity": "sha512-hlc64xJiDjY2w+JG6P7Ejby2bW5Jad73CB6wJuKejAQPAAKfb/dJaxFpaSxvdWrhn8O5aoBQcBvA7zt7G5/fHw==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.5.8.tgz",
+      "integrity": "sha512-1mABf1bXyn3AOHyQkios4FTGqoARa8y1tf7GMH6t1c7q0nAMSbpXoTDdjEidUHy8qhWoG0y3Ez4PjCi8WQnmMg==",
       "funding": [
         {
           "type": "gitcoin",
@@ -5745,9 +5745,8 @@
         }
       ],
       "dependencies": {
-        "abitype": "^0.1.7",
         "eventemitter3": "^4.0.7",
-        "zustand": "^4.1.1"
+        "zustand": "^4.0.0"
       },
       "peerDependencies": {
         "@coinbase/wallet-sdk": ">=3.3.0",
@@ -6218,23 +6217,6 @@
         "graphql-request": "^4.2.0",
         "graphql-tag": "^2.12.6",
         "tslib": "^2.2.0"
-      }
-    },
-    "node_modules/abitype": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.7.tgz",
-      "integrity": "sha512-mNBIrA8xbkR0PrxXSO/7p3irNhyLKO6S4VfU3YrR37cqpJIq1D63Yg8KlovOZkCVAaQ+lJkGDkOhSpv1QmMXIg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "engines": {
-        "pnpm": ">=7"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.7.4"
       }
     },
     "node_modules/abort-controller": {
@@ -12926,9 +12908,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-      "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14037,6 +14019,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
       "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14420,9 +14403,9 @@
       "peer": true
     },
     "node_modules/wagmi": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.7.10.tgz",
-      "integrity": "sha512-/of5PUwKWbQV6jQEHyBhBkdVR9V3A1GSffHuaeiKGeENipBnRNK5T7EBjEcYmyz771SiVru/awcUts8tIiiJaA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.6.8.tgz",
+      "integrity": "sha512-pIOn7I56KPfdPQ1WRIWzWnpC8eJZm1V25Rcn5fbgOJ2eV3kjGNchnIub/ERY1VMKywxkCAfgXfn2D/tqwCJsWw==",
       "funding": [
         {
           "type": "gitcoin",
@@ -14434,13 +14417,12 @@
         }
       ],
       "dependencies": {
-        "@coinbase/wallet-sdk": "^3.5.3",
-        "@tanstack/query-sync-storage-persister": "^4.10.1",
-        "@tanstack/react-query": "^4.10.1",
-        "@tanstack/react-query-persist-client": "^4.10.1",
-        "@wagmi/core": "^0.6.9",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.1.7",
+        "@coinbase/wallet-sdk": "^3.3.0",
+        "@tanstack/query-sync-storage-persister": "^4.0.10",
+        "@tanstack/react-query": "^4.0.10",
+        "@tanstack/react-query-persist-client": "^4.0.10",
+        "@wagmi/core": "^0.5.8",
+        "@walletconnect/ethereum-provider": "^1.7.8",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
@@ -14833,9 +14815,9 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.19.0.tgz",
-      "integrity": "sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.2.tgz",
+      "integrity": "sha512-k22GoYRAHPYr9I+Gvy2ZQlAe5mGy8BqWst2wRt8cwIufWTxrsVshhIBvYNqC80N0GSFWTsqRVexOtfzlgOEDvA==",
       "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
@@ -14843,7 +14825,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-member-expression-to-functions": "^7.18.9",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
@@ -14943,9 +14925,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.19.0.tgz",
-      "integrity": "sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw=="
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.18.9",
@@ -15173,16 +15155,16 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.19.4.tgz",
-      "integrity": "sha512-wHmj6LDxVDnL+3WhXteUBaoM1aVILZODAUjg11kHqG4cOlfgMQGxw6aCgvrXrmaJR3Bn14oZhImyCPZzRpC93Q==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.2.tgz",
+      "integrity": "sha512-Ks6uej9WFK+fvIMesSqbAto5dD8Dz4VuuFvGJFKgIGSkJuRGcrwGECPA1fDgQK3/DbExBJpEkTeYeB8geIFCSQ==",
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.18.8"
+        "@babel/plugin-transform-parameters": "^7.20.1"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
@@ -15438,27 +15420,27 @@
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.0.tgz",
-      "integrity": "sha512-sXOohbpHZSk7GjxK9b3dKB7CfqUD5DwOH+DggKzOQ7TXYP+RCSbRykfjQmn/zq+rBjycVRtLf9pYhAaEJA786w==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.2.tgz",
+      "integrity": "sha512-y5V15+04ry69OV2wULmwhEA6jwSWXO1TwAtIwiPXcvHcoOQUqpyMVd2bDsQJMW8AurjulIyUV8kDqtjSwHy1uQ==",
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.19.0.tgz",
-      "integrity": "sha512-YfeEE9kCjqTS9IitkgfJuxjcEtLUHMqa8yUJ6zdz8vR7hKuo6mOy2C05P0F1tdMmDCeuyidKnlrw/iTppHcr2A==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.2.tgz",
+      "integrity": "sha512-9rbPp0lCVVoagvtEyQKSo5L8oo0nQS/iif+lwlAz29MccX2642vWDlSZK+2T2buxbopotId2ld7zZAzRfz9j1g==",
       "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
-        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.20.0",
         "@babel/helper-environment-visitor": "^7.18.9",
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-optimise-call-expression": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.19.0",
-        "@babel/helper-replace-supers": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.19.1",
         "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       }
@@ -15473,12 +15455,12 @@
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.0.tgz",
-      "integrity": "sha512-1dIhvZfkDVx/zn2S1aFwlruspTt4189j7fEkH0Y0VyuDM6bQt7bD6kLcz3l4IlLG+e5OReaBz9ROAbttRtUHqA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.2.tgz",
+      "integrity": "sha512-mENM+ZHrvEgxLTBXUiQ621rRXZes3KWUv6NdQlrnr1TkWVw+hUjQBZuP2X32qKlrlG2BzgR95gkuCRSkJl8vIw==",
       "peer": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.19.0"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
@@ -15773,13 +15755,13 @@
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.0.tgz",
-      "integrity": "sha512-xOAsAFaun3t9hCwZ13Qe7gq423UgMZ6zAgmLxeGGapFqlT/X3L5qT2btjiVLlFn7gWtMaVyceS5VxGAuKbgizw==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.2.tgz",
+      "integrity": "sha512-jvS+ngBfrnTUBfOQq8NfGnSbF9BrqlR6hjJ2yVxMkmO5nL/cdifNbI30EfjRlN4g5wYWNnMPyj5Sa6R1pbLeag==",
       "peer": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.19.0",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/helper-create-class-features-plugin": "^7.20.2",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-typescript": "^7.20.0"
       }
     },
@@ -15803,18 +15785,18 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.19.4",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.19.4.tgz",
-      "integrity": "sha512-5QVOTXUdqTCjQuh2GGtdd7YEhoRXBMVGROAtsBeLGIbIz3obCBIfRMT1I3ZKkMgNzwkyCkftDXSSkHxnfVf4qg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "peer": true,
       "requires": {
-        "@babel/compat-data": "^7.19.4",
-        "@babel/helper-compilation-targets": "^7.19.3",
-        "@babel/helper-plugin-utils": "^7.19.0",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/helper-validator-option": "^7.18.6",
         "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
-        "@babel/plugin-proposal-async-generator-functions": "^7.19.1",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
         "@babel/plugin-proposal-class-static-block": "^7.18.6",
         "@babel/plugin-proposal-dynamic-import": "^7.18.6",
@@ -15823,7 +15805,7 @@
         "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
         "@babel/plugin-proposal-numeric-separator": "^7.18.6",
-        "@babel/plugin-proposal-object-rest-spread": "^7.19.4",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
         "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
         "@babel/plugin-proposal-optional-chaining": "^7.18.9",
         "@babel/plugin-proposal-private-methods": "^7.18.6",
@@ -15834,7 +15816,7 @@
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-import-assertions": "^7.18.6",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -15847,10 +15829,10 @@
         "@babel/plugin-transform-arrow-functions": "^7.18.6",
         "@babel/plugin-transform-async-to-generator": "^7.18.6",
         "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
-        "@babel/plugin-transform-block-scoping": "^7.19.4",
-        "@babel/plugin-transform-classes": "^7.19.0",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
         "@babel/plugin-transform-computed-properties": "^7.18.9",
-        "@babel/plugin-transform-destructuring": "^7.19.4",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
         "@babel/plugin-transform-dotall-regex": "^7.18.6",
         "@babel/plugin-transform-duplicate-keys": "^7.18.9",
         "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
@@ -15858,14 +15840,14 @@
         "@babel/plugin-transform-function-name": "^7.18.9",
         "@babel/plugin-transform-literals": "^7.18.9",
         "@babel/plugin-transform-member-expression-literals": "^7.18.6",
-        "@babel/plugin-transform-modules-amd": "^7.18.6",
-        "@babel/plugin-transform-modules-commonjs": "^7.18.6",
-        "@babel/plugin-transform-modules-systemjs": "^7.19.0",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
         "@babel/plugin-transform-modules-umd": "^7.18.6",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
         "@babel/plugin-transform-new-target": "^7.18.6",
         "@babel/plugin-transform-object-super": "^7.18.6",
-        "@babel/plugin-transform-parameters": "^7.18.8",
+        "@babel/plugin-transform-parameters": "^7.20.1",
         "@babel/plugin-transform-property-literals": "^7.18.6",
         "@babel/plugin-transform-regenerator": "^7.18.6",
         "@babel/plugin-transform-reserved-words": "^7.18.6",
@@ -15877,7 +15859,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.18.10",
         "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.19.4",
+        "@babel/types": "^7.20.2",
         "babel-plugin-polyfill-corejs2": "^0.3.3",
         "babel-plugin-polyfill-corejs3": "^0.6.0",
         "babel-plugin-polyfill-regenerator": "^0.4.1",
@@ -15969,9 +15951,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.20.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.0.tgz",
-      "integrity": "sha512-Jlgt3H0TajCW164wkTOTzHkZb075tMQMULzrLUoUeKmO7eFL96GgDxf7/Axhc5CAuKE3KFyVW1p6ysKsi2oXAg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.2.tgz",
+      "integrity": "sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==",
       "requires": {
         "@babel/helper-string-parser": "^7.19.4",
         "@babel/helper-validator-identifier": "^7.19.1",
@@ -18410,9 +18392,9 @@
           }
         },
         "react-native": {
-          "version": "0.70.4",
-          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.4.tgz",
-          "integrity": "sha512-1e4jWotS20AJ/4lGVkZQs2wE0PvCpIRmPQEQ1FyH7wdyuewFFIxbUHqy6vAj1JWVFfAzbDakOQofrIkkHWLqNA==",
+          "version": "0.70.5",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.70.5.tgz",
+          "integrity": "sha512-5NZM80LC3L+TIgQX/09yiyy48S73wMgpIgN5cCv3XTMR394+KpDI3rBZGH4aIgWWuwijz31YYVF5504+9n2Zfw==",
           "peer": true,
           "requires": {
             "@jest/create-cache-key-function": "^29.0.3",
@@ -18833,13 +18815,12 @@
       }
     },
     "@wagmi/core": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.6.9.tgz",
-      "integrity": "sha512-hlc64xJiDjY2w+JG6P7Ejby2bW5Jad73CB6wJuKejAQPAAKfb/dJaxFpaSxvdWrhn8O5aoBQcBvA7zt7G5/fHw==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.5.8.tgz",
+      "integrity": "sha512-1mABf1bXyn3AOHyQkios4FTGqoARa8y1tf7GMH6t1c7q0nAMSbpXoTDdjEidUHy8qhWoG0y3Ez4PjCi8WQnmMg==",
       "requires": {
-        "abitype": "^0.1.7",
         "eventemitter3": "^4.0.7",
-        "zustand": "^4.1.1"
+        "zustand": "^4.0.0"
       }
     },
     "@walletconnect/browser-utils": {
@@ -19237,12 +19218,6 @@
         "graphql-tag": "^2.12.6",
         "tslib": "^2.2.0"
       }
-    },
-    "abitype": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.1.7.tgz",
-      "integrity": "sha512-mNBIrA8xbkR0PrxXSO/7p3irNhyLKO6S4VfU3YrR37cqpJIq1D63Yg8KlovOZkCVAaQ+lJkGDkOhSpv1QmMXIg==",
-      "requires": {}
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -24350,9 +24325,9 @@
       },
       "dependencies": {
         "ws": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.10.0.tgz",
-          "integrity": "sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
+          "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
           "requires": {}
         }
       }
@@ -25258,7 +25233,8 @@
     "typescript": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig=="
+      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "dev": true
     },
     "uglify-es": {
       "version": "3.3.9",
@@ -25510,17 +25486,16 @@
       "peer": true
     },
     "wagmi": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.7.10.tgz",
-      "integrity": "sha512-/of5PUwKWbQV6jQEHyBhBkdVR9V3A1GSffHuaeiKGeENipBnRNK5T7EBjEcYmyz771SiVru/awcUts8tIiiJaA==",
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.6.8.tgz",
+      "integrity": "sha512-pIOn7I56KPfdPQ1WRIWzWnpC8eJZm1V25Rcn5fbgOJ2eV3kjGNchnIub/ERY1VMKywxkCAfgXfn2D/tqwCJsWw==",
       "requires": {
-        "@coinbase/wallet-sdk": "^3.5.3",
-        "@tanstack/query-sync-storage-persister": "^4.10.1",
-        "@tanstack/react-query": "^4.10.1",
-        "@tanstack/react-query-persist-client": "^4.10.1",
-        "@wagmi/core": "^0.6.9",
-        "@walletconnect/ethereum-provider": "^1.8.0",
-        "abitype": "^0.1.7",
+        "@coinbase/wallet-sdk": "^3.3.0",
+        "@tanstack/query-sync-storage-persister": "^4.0.10",
+        "@tanstack/react-query": "^4.0.10",
+        "@tanstack/react-query-persist-client": "^4.0.10",
+        "@wagmi/core": "^0.5.8",
+        "@walletconnect/ethereum-provider": "^1.7.8",
         "use-sync-external-store": "^1.2.0"
       }
     },

--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -20,7 +20,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
-        "siwe": "^2.1.3",
+        "siwe": "~2.0.5",
         "wagmi": "~0.6.7"
       },
       "devDependencies": {
@@ -4063,17 +4063,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
     "node_modules/@pedrouid/environment": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
@@ -5298,14 +5287,16 @@
       }
     },
     "node_modules/@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.0.tgz",
+      "integrity": "sha512-zXlPBRKaT9ecxhhLQqn/StAWlXvQBlFDFnIAlM7ceMVx/1NVZZ65GdW9A28tYGbhpesYxNYpsqegGsBcrWuASg==",
       "dependencies": {
-        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
+      },
+      "peerDependencies": {
+        "keccak": "^3.0.2"
       }
     },
     "node_modules/@stablelib/base64": {
@@ -13240,11 +13231,11 @@
       "peer": true
     },
     "node_modules/siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.0.5.tgz",
+      "integrity": "sha512-PZku0+V915YvzVuProsC+RD6unKBo3208X/+t9ARk1WHjYMbtGnxuyBuMASdmLFI3nqJiorko5qrT0ihCFwlHQ==",
       "dependencies": {
-        "@spruceid/siwe-parser": "^2.0.2",
+        "@spruceid/siwe-parser": "2.0.0",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -17515,11 +17506,6 @@
         "tslib": "^2.3.1"
       }
     },
-    "@noble/hashes": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
-      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A=="
-    },
     "@pedrouid/environment": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
@@ -18466,11 +18452,10 @@
       }
     },
     "@spruceid/siwe-parser": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.2.tgz",
-      "integrity": "sha512-9WuA0ios2537cWYu39MMeH0O2KdrMKgKlOBUTWRTXQjCYu5B+mHCA0JkCbFaJ/0EjxoVIcYCXIW/DoPEpw+PqA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.0.0.tgz",
+      "integrity": "sha512-zXlPBRKaT9ecxhhLQqn/StAWlXvQBlFDFnIAlM7ceMVx/1NVZZ65GdW9A28tYGbhpesYxNYpsqegGsBcrWuASg==",
       "requires": {
-        "@noble/hashes": "^1.1.2",
         "apg-js": "^4.1.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"
@@ -24594,11 +24579,11 @@
       "peer": true
     },
     "siwe": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.1.3.tgz",
-      "integrity": "sha512-d20jADr6MI6oWPDHg9bE+CBsUYkQQ2g4+ayCQ3QapAuYeE/dvFWI/7lwOOV21EuqZMmyrLVOSezgVoq0HAn8yw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.0.5.tgz",
+      "integrity": "sha512-PZku0+V915YvzVuProsC+RD6unKBo3208X/+t9ARk1WHjYMbtGnxuyBuMASdmLFI3nqJiorko5qrT0ihCFwlHQ==",
       "requires": {
-        "@spruceid/siwe-parser": "^2.0.2",
+        "@spruceid/siwe-parser": "2.0.0",
         "@stablelib/random": "^1.0.1",
         "uri-js": "^4.4.1",
         "valid-url": "^1.0.9"

--- a/garage/package.json
+++ b/garage/package.json
@@ -22,7 +22,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
     "siwe": "^2.1.3",
-    "wagmi": "^0.7.10"
+    "wagmi": "~0.6.7"
   },
   "devDependencies": {
     "@types/react": "^18.0.17",

--- a/garage/package.json
+++ b/garage/package.json
@@ -21,7 +21,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
-    "siwe": "^2.1.3",
+    "siwe": "~2.0.5",
     "wagmi": "~0.6.7"
   },
   "devDependencies": {

--- a/garage/src/env.ts
+++ b/garage/src/env.ts
@@ -1,6 +1,6 @@
 import { chain as chains } from "wagmi";
 // import { deployments } from "@tableland/rigs/deployments";
-import { deployments } from "../../ethereum/deployments";
+import { deployments } from "ethereum/deployments";
 
 export const environment =
   process.env.NODE_ENV === "development" ? "development" : "production";

--- a/garage/src/env.ts
+++ b/garage/src/env.ts
@@ -1,5 +1,6 @@
 import { chain as chains } from "wagmi";
-import { deployments, RigsDeployment } from "@tableland/rigs/deployments";
+// import { deployments } from "@tableland/rigs/deployments";
+import { deployments } from "../../ethereum/deployments";
 
 export const environment =
   process.env.NODE_ENV === "development" ? "development" : "production";

--- a/garage/src/env.ts
+++ b/garage/src/env.ts
@@ -13,21 +13,8 @@ export const blockExplorerBaseUrl = isDevelopment
   ? "https://mumbai.polygonscan.com"
   : "https://etherscan.io";
 
-type SimplifiedDeployment = Pick<
-  RigsDeployment,
-  "attributesTable" | "lookupsTable" | "pilotSessionsTable" | "contractAddress"
->;
-
-// TODO(daniel): once the data in @tableland/rigs is up to date just reference
-// deployments["polygon-mumbai"] and deployments.ethereum
-// and remove SimplifiedDeployment
-export const deployment: SimplifiedDeployment = isDevelopment
-  ? {
-      attributesTable: "rig_attributes_80001_3507",
-      lookupsTable: "lookups_80001_3508",
-      pilotSessionsTable: "pilot_sessions_80001_3515",
-      contractAddress: "0x2f9EE58e25D1AcA55841D98f7f1b0aEbD11750Bc",
-    }
+export const deployment = isDevelopment
+  ? deployments["polygon-mumbai"]
   : deployments.ethereum;
 
 export const ipfsGatewayBaseUrl = isDevelopment

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -19,7 +19,6 @@ import { TOPBAR_HEIGHT } from "../../Topbar";
 import { RigDisplay } from "../../components/RigDisplay";
 import { FlightLog } from "./modules/FlightLog";
 import { Pilots } from "./modules/Pilots";
-import { Badges } from "./modules/Badges";
 import { RigAttributes } from "./modules/RigAttributes";
 import { findNFT } from "../../utils/nfts";
 import { sleep, runUntilConditionMet } from "../../utils/async";
@@ -134,7 +133,6 @@ export const RigDetails = () => {
                   onOpenTrainModal={onOpenTrainModal}
                   {...MODULE_PROPS}
                 />
-                <Badges rig={rig} nfts={nfts} {...MODULE_PROPS} />
                 <FlightLog rig={rig} nfts={nfts} {...MODULE_PROPS} />
               </VStack>
             </GridItem>

--- a/garage/tsconfig.json
+++ b/garage/tsconfig.json
@@ -14,7 +14,10 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "ethereum/deployments": ["../ethereum/deployments"]
+    }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/garage/vite.config.ts
+++ b/garage/vite.config.ts
@@ -1,7 +1,18 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { resolve } from "path";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
-})
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "ethereum/deployments": resolve(
+        __dirname,
+        "..",
+        "ethereum",
+        "deployments.ts"
+      ),
+    },
+  },
+});


### PR DESCRIPTION
- Fixes a dependency issue introduced by dependabot in https://github.com/tablelandnetwork/rigs/pull/311 where wagmi was updated to v0.7.x which is incompatible with our version of rainbowkit. There is a breaking change in the wagmi upgrade v0.6 -> v0.7, I'm gonna work on upgrading the app to use v0.7
- Reads deployment info directly from `ethereum/deployments.ts` instead of the npm package
- Removes the badges section with dummy data from the rig details screen