### PR TITLE
Publish layers and renders fix

### DIFF
--- a/cmd/rigs/cmd/publish_layers.go
+++ b/cmd/rigs/cmd/publish_layers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/spf13/cobra"
@@ -14,6 +15,8 @@ func init() {
 	layersCmd.Flags().String("layers-path", "./artifacts/layers", "local filesystem path to the layer images")
 	layersCmd.Flags().String("cid", "", "cid of the layers images")
 	layersCmd.Flags().String("chunks-dir", "", "directory where car chunks are written")
+	layersCmd.Flags().Int("concurrency", 2, "number of concurrent uploads to nft.storage")
+	layersCmd.Flags().Duration("rate-limit", time.Millisecond*350, "rate limit for uploads to nft.storage")
 }
 
 var layersCmd = &cobra.Command{
@@ -42,7 +45,12 @@ var layersCmd = &cobra.Command{
 			checkErr(err)
 			fmt.Printf("Car chunks written to folder %s\n", chunksDir)
 		}
-		checkErr(dirPublisher.CarChunksToNftStorage(ctx, chunksDir))
+		checkErr(dirPublisher.CarChunksToNftStorage(
+			ctx,
+			chunksDir,
+			viper.GetInt("concurrency"),
+			viper.GetDuration("rate-limit"),
+		))
 		fmt.Printf("Layers published with cid %s\n", c.String())
 	},
 }

--- a/cmd/rigs/cmd/publish_layers.go
+++ b/cmd/rigs/cmd/publish_layers.go
@@ -32,12 +32,12 @@ var layersCmd = &cobra.Command{
 		}
 		chunksDir := viper.GetString("chunks-dir")
 
-		if chunksDir == "" && c.String() == "" {
+		if chunksDir == "" && !c.Defined() {
 			c, err = dirPublisher.DirToIpfs(ctx, path, "layers")
 			checkErr(err)
 			fmt.Printf("Images added to IPFS with cid %s\n", c.String())
 		}
-		if chunksDir == "" && c.String() != "" {
+		if chunksDir == "" && c.Defined() {
 			chunksDir, err = dirPublisher.CidToCarChunks(ctx, c)
 			checkErr(err)
 			fmt.Printf("Car chunks written to folder %s\n", chunksDir)

--- a/cmd/rigs/cmd/publish_renders.go
+++ b/cmd/rigs/cmd/publish_renders.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/spf13/cobra"
@@ -12,6 +13,8 @@ func init() {
 	rendersCmd.Flags().String("renders-path", "./renders", "path to the rendered images")
 	rendersCmd.Flags().String("cid", "", "cid of the rendered images")
 	rendersCmd.Flags().String("chunks-dir", "", "directory where car chunks are written")
+	rendersCmd.Flags().Int("concurrency", 2, "number of concurrent uploads to nft.storage")
+	rendersCmd.Flags().Duration("rate-limit", time.Millisecond*350, "rate limit for uploads to nft.storage")
 
 	publishCmd.AddCommand(rendersCmd)
 }
@@ -42,7 +45,12 @@ var rendersCmd = &cobra.Command{
 			checkErr(err)
 			fmt.Printf("Car chunks written to folder %s\n", chunksDir)
 		}
-		checkErr(dirPublisher.CarChunksToNftStorage(ctx, chunksDir))
+		checkErr(dirPublisher.CarChunksToNftStorage(
+			ctx,
+			chunksDir,
+			viper.GetInt("concurrency"),
+			viper.GetDuration("rate-limit"),
+		))
 		fmt.Printf("Renders published with cid %s\n", c.String())
 	},
 }

--- a/cmd/rigs/cmd/publish_renders.go
+++ b/cmd/rigs/cmd/publish_renders.go
@@ -32,12 +32,12 @@ var rendersCmd = &cobra.Command{
 		}
 		chunksDir := viper.GetString("chunks-dir")
 
-		if chunksDir == "" && c.String() == "" {
+		if chunksDir == "" && !c.Defined() {
 			c, err = dirPublisher.DirToIpfs(ctx, path, "renders")
 			checkErr(err)
 			fmt.Printf("Images added to IPFS with cid %s\n", c.String())
 		}
-		if chunksDir == "" && c.String() != "" {
+		if chunksDir == "" && c.Defined() {
 			chunksDir, err = dirPublisher.CidToCarChunks(ctx, c)
 			checkErr(err)
 			fmt.Printf("Car chunks written to folder %s\n", chunksDir)

--- a/pkg/dirpublisher/dirpublisher.go
+++ b/pkg/dirpublisher/dirpublisher.go
@@ -163,7 +163,12 @@ L0:
 }
 
 // CarChunksToNftStorage publishes the car chunks in the specified dir to nft.storage.
-func (dp *DirPublisher) CarChunksToNftStorage(ctx context.Context, tmpDir string) error {
+func (dp *DirPublisher) CarChunksToNftStorage(
+	ctx context.Context,
+	tmpDir string,
+	concurrency int,
+	rateLimit time.Duration,
+) error {
 	chunks, err := os.ReadDir(tmpDir)
 	if err != nil {
 		return fmt.Errorf("reading tmp dir: %v", err)
@@ -193,7 +198,7 @@ func (dp *DirPublisher) CarChunksToNftStorage(ctx context.Context, tmpDir string
 	ctx1, cancel1 := context.WithCancel(ctx)
 	defer cancel1()
 
-	p1 := wpool.New(1, rate.Every(time.Millisecond*350))
+	p1 := wpool.New(concurrency, rate.Every(rateLimit))
 	go p1.GenerateFrom(jobs1)
 	go p1.Run(ctx1)
 L1:


### PR DESCRIPTION
Ended up being a stupid bug in processing and using cli flags then properly detecting the empty value of a `cid.Cid`. Also added some flags to make nft.storage upload concurrency and rate limit configurable.