### PR TITLE
Garage: minor layout fixes

### DIFF
--- a/garage/src/pages/Dashboard/index.tsx
+++ b/garage/src/pages/Dashboard/index.tsx
@@ -22,7 +22,7 @@ export const Dashboard = () => {
         direction="column"
         align="center"
         width="100%"
-        minHeight={`calc(100vh - ${TOPBAR_HEIGHT}) + 40px`}
+        minHeight={`calc(100vh - ${TOPBAR_HEIGHT} + 40px)`}
         mb="40px"
       >
         <Flex

--- a/garage/src/pages/Enter.tsx
+++ b/garage/src/pages/Enter.tsx
@@ -35,11 +35,11 @@ export const Enter = () => {
       width="100%"
       minHeight={`calc(100vh - ${TOPBAR_HEIGHT})`}
     >
-      <Stack maxWidth="650px" align="center" color="white">
+      <Stack maxWidth="700px" align="center" color="white" px={4} textAlign="center">
         <Heading as="h1" variant="orbitron" fontSize="64">
           Enter the Garage.
         </Heading>
-        <Text textAlign="center" fontSize="16" pt={6} pb={12} maxWidth="445px">
+        <Text fontSize="16" pt={6} pb={12} maxWidth="445px">
           Tired? Thirsty? Sunburned? Come take a break from the heat and hang
           with other Rig owners from across Tableland. Learn how to pilot your
           Rig to earn flight-time and badges in the Garage.


### PR DESCRIPTION
Fixes a typo in a css calculation + improves text spacing and alignment on the Enter page so that it looks better on mobile.

New:
<img width="421" alt="image" src="https://user-images.githubusercontent.com/656107/200842307-bbc9e910-aad4-4932-8e72-e43ee741226d.png">

Old:
<img width="415" alt="image" src="https://user-images.githubusercontent.com/656107/200842374-253c264d-b8c5-4dfa-8792-592647eecf48.png">
