### PR TITLE
Remove onlyParent modifier from external view functions

### DIFF
--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -108,12 +108,7 @@ contract TablelandRigPilots is
     /**
      * @dev See {ITablelandRigPilots-pilotSessionsTable}.
      */
-    function pilotSessionsTable()
-        external
-        view
-        onlyParent
-        returns (string memory)
-    {
+    function pilotSessionsTable() external view returns (string memory) {
         return
             SQLHelpers.toNameFromId(
                 _PILOT_SESSIONS_PREFIX,
@@ -126,7 +121,7 @@ contract TablelandRigPilots is
      */
     function pilotInfo(
         uint256 tokenId
-    ) external view onlyParent returns (PilotInfo memory) {
+    ) external view returns (PilotInfo memory) {
         return
             PilotInfo(
                 _pilotStatus(tokenId),
@@ -142,9 +137,7 @@ contract TablelandRigPilots is
     /**
      * @dev See {ITablelandRigPilots-pilotStartTime}.
      */
-    function pilotStartTime(
-        uint256 tokenId
-    ) public view onlyParent returns (uint64) {
+    function pilotStartTime(uint256 tokenId) public view returns (uint64) {
         return uint64(_pilots[uint16(tokenId)]);
     }
 

--- a/ethereum/test/TablelandRigPilots.ts
+++ b/ethereum/test/TablelandRigPilots.ts
@@ -73,36 +73,6 @@ describe("Pilots", function () {
     });
   });
 
-  describe("pilotSessionsTable", function () {
-    it("Should only allow contract parent", async function () {
-      const _pilots = pilots.connect(accounts[2]);
-
-      await expect(_pilots.pilotSessionsTable()).to.be.rejectedWith(
-        "Pilots: caller is not the parent"
-      );
-    });
-  });
-
-  describe("pilotInfo", function () {
-    it("Should only allow contract parent", async function () {
-      const _pilots = pilots.connect(accounts[2]);
-
-      await expect(_pilots.pilotInfo(BigNumber.from(1))).to.be.rejectedWith(
-        "Pilots: caller is not the parent"
-      );
-    });
-  });
-
-  describe("pilotStartTime", function () {
-    it("Should only allow contract parent", async function () {
-      const _pilots = pilots.connect(accounts[2]);
-
-      await expect(
-        _pilots.pilotStartTime(BigNumber.from(1))
-      ).to.be.rejectedWith("Pilots: caller is not the parent");
-    });
-  });
-
   describe("trainRig", function () {
     it("Should only allow contract parent", async function () {
       const _pilots = pilots.connect(accounts[2]);


### PR DESCRIPTION
I think it should be safe to remove the modifier since they don't expose anything sensitive and don't mutate anything? Saves a tiiiny bit of gas for the train/park/pilot calls