### PR TITLE
New Rig attributes table on Arbitrum

### DIFF
--- a/ethereum/deployments.ts
+++ b/ethereum/deployments.ts
@@ -41,7 +41,7 @@ export const deployments: RigsDeployments = {
     allowlistTable: "rigs_allowlist_42161_14",
     partsTable: "parts_42161_7",
     layersTable: "layers_42161_8",
-    attributesTable: "rig_attributes_42161_9",
+    attributesTable: "rig_attributes_42161_15",
     lookupsTable: "lookups_42161_10",
     pilotSessionsTable: "pilot_sessions_1_7",
     displayAttributes: true,


### PR DESCRIPTION
Uses the new attribute value column of `text` type to be compatible with updates to the Tableland SQL spec that don't allow floating point numbers.

New table is `rig_attributes_42161_15`. All the other Arbitrum tables remain the same.

The changes in this PR are only to `artifacts/local.db` which tracks the name of each table on each chain as well as the transaction information from inserting data into the tables.

Closes #420 