### PR TITLE
fix: pilot contract bugs & logic

### DIFF
--- a/ethereum/.openzeppelin/polygon-mumbai.json
+++ b/ethereum/.openzeppelin/polygon-mumbai.json
@@ -4529,6 +4529,284 @@
           }
         }
       }
+    },
+    "a69c1538e7eb6ddf0b6e6cb5decad09e84bdd46fec60b6c747f6cc4f80d6220a": {
+      "address": "0xA7448046BfC0aCd6E6088089e5Dd5DB90aE2e9D7",
+      "txHash": "0xc76150a349ec0f501d87a7640502911b701710ce7274e41911ca268a682e577c",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "_parent",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:45"
+          },
+          {
+            "label": "_pilotSessionsTableId",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_uint256",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:48"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_mapping(t_uint16,t_uint256)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:56"
+          },
+          {
+            "label": "_pilotIndex",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_mapping(t_uint192,t_uint16)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:60"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint16,t_uint256)": {
+            "label": "mapping(uint16 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint192,t_uint16)": {
+            "label": "mapping(uint192 => uint16)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint192": {
+            "label": "uint192",
+            "numberOfBytes": "24"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "00f7a404d3eec3c15878805172bd60217f810bc9e3babf273f250731a3c1fc49": {
+      "address": "0x9FBB6E746D8321F2E6f8A6f2e51117b50F56C2b1",
+      "txHash": "0x78a08c3561029ec1b443c2679e9bfd9df757782b939c13f6d5d1ef3e80183474",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "_parent",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:45"
+          },
+          {
+            "label": "_pilotSessionsTableId",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_uint256",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:48"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_mapping(t_uint16,t_uint256)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:56"
+          },
+          {
+            "label": "_pilotIndex",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_mapping(t_uint192,t_uint16)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:60"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint16,t_uint256)": {
+            "label": "mapping(uint16 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint192,t_uint16)": {
+            "label": "mapping(uint192 => uint16)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint192": {
+            "label": "uint192",
+            "numberOfBytes": "24"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -327,7 +327,7 @@ contract TablelandRigPilots is
             string memory setters = string.concat(
                 "pilot_contract=",
                 SQLHelpers.quote(StringsUpgradeable.toHexString(pilotAddr)),
-                "pilot_id=",
+                ",pilot_id=",
                 StringsUpgradeable.toString(uint32(pilotId))
             );
             string memory filters = string.concat(

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -413,11 +413,8 @@ contract TablelandRigPilots is
         } else {
             // Training is complete; update the row in the pilot sessions table with its `end_time`
             setters = string.concat(
-                "end_time=(",
-                StringsUpgradeable.toString(uint64(block.number)),
-                "-",
-                StringsUpgradeable.toString(startTime),
-                ")"
+                "end_time=",
+                StringsUpgradeable.toString(uint64(block.number))
             );
         }
 

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -320,16 +320,15 @@ contract TablelandRigPilots is
             _pilotStatus(_pilotIndex[pilotData]) != GarageStatus.PARKED
         ) parkRig(sender, _pilotIndex[pilotData]);
 
-        // If the Rig is training, update its session (no parking required)
+        // If the Rig is training, end its training session (no parking required) to then open a new pilot session
         // Pilot has completed training at this point (training validation is checked above)
         if (_pilotStatus(tokenId) == GarageStatus.TRAINING) {
-            // Update the pilot's existing session with its new pilot data
+            // Update the pilot's existing training session with its `end_time`
             string memory setters = string.concat(
-                "pilot_contract=",
-                SQLHelpers.quote(StringsUpgradeable.toHexString(pilotAddr)),
-                ",pilot_id=",
-                StringsUpgradeable.toString(uint32(pilotId))
+                "end_time=",
+                StringsUpgradeable.toString(uint64(block.number))
             );
+            // Only update the row with the matching `rig_id` and `start_time`
             string memory filters = string.concat(
                 "rig_id=",
                 StringsUpgradeable.toString(uint16(tokenId)),
@@ -347,34 +346,32 @@ contract TablelandRigPilots is
                     filters
                 )
             );
-        } else {
-            // The Rig is `PARKED`; set the start time for the new pilot session
-            _setStartTime(uint16(tokenId), uint64(block.number));
-
-            // Insert the pilot into the Tableland pilot sessions table
-            TablelandDeployments.get().runSQL(
-                address(this),
-                _pilotSessionsTableId,
-                SQLHelpers.toInsert(
-                    _PILOT_SESSIONS_PREFIX,
-                    _pilotSessionsTableId,
-                    "rig_id,owner,pilot_contract,pilot_id,start_time",
-                    string.concat(
-                        StringsUpgradeable.toString(uint16(tokenId)),
-                        ",",
-                        SQLHelpers.quote(
-                            StringsUpgradeable.toHexString(sender)
-                        ),
-                        ",",
-                        SQLHelpers.quote(Strings.toHexString(pilotAddr)),
-                        ",",
-                        StringsUpgradeable.toString(uint32(pilotId)),
-                        ",",
-                        StringsUpgradeable.toString(uint64(block.number))
-                    )
-                )
-            );
         }
+        // The Rig is either `PARKED` or setting its first pilot while in a `TRAINED` status
+        // Set the start time for the new pilot session
+        _setStartTime(uint16(tokenId), uint64(block.number));
+
+        // Insert the pilot into the Tableland pilot sessions table
+        TablelandDeployments.get().runSQL(
+            address(this),
+            _pilotSessionsTableId,
+            SQLHelpers.toInsert(
+                _PILOT_SESSIONS_PREFIX,
+                _pilotSessionsTableId,
+                "rig_id,owner,pilot_contract,pilot_id,start_time",
+                string.concat(
+                    StringsUpgradeable.toString(uint16(tokenId)),
+                    ",",
+                    SQLHelpers.quote(StringsUpgradeable.toHexString(sender)),
+                    ",",
+                    SQLHelpers.quote(Strings.toHexString(pilotAddr)),
+                    ",",
+                    StringsUpgradeable.toString(uint32(pilotId)),
+                    ",",
+                    StringsUpgradeable.toString(uint64(block.number))
+                )
+            )
+        );
 
         // Avoid overwriting existing pilot if data is unchanged
         // (i.e., if most recent pilot is the same as the one specified)

--- a/ethereum/scripts/verify.ts
+++ b/ethereum/scripts/verify.ts
@@ -26,27 +26,62 @@ async function main() {
     rigsDeployment.contractAddress
   );
   let impl = await upgrades.erc1967.getImplementationAddress(rigs.address);
-  await run("verify:verify", {
-    address: impl,
-  });
+  try {
+    await run("verify:verify", {
+      address: impl,
+    });
+  } catch (err) {
+    // Check if the error is via hardhat or etherscan where already verified contracts throw a halting error
+    // If it's an etherscan issue, "Reason: Already Verified" is embedded within a hardhat error message
+    if (
+      err.message === "Contract source code already verified" ||
+      err.message.includes("Reason: Already Verified")
+    ) {
+      console.log(
+        `Rigs contract already verified: '${rigsDeployment.contractAddress}'`
+      );
+    } else throw err;
+  }
 
   // Verify pilots
   const pilots = (await ethers.getContractFactory("TablelandRigPilots")).attach(
     rigsDeployment.pilotsAddress
   );
   impl = await upgrades.erc1967.getImplementationAddress(pilots.address);
-  await run("verify:verify", {
-    address: impl,
-  });
+  try {
+    await run("verify:verify", {
+      address: impl,
+    });
+  } catch (err) {
+    if (
+      err.message === "Contract source code already verified" ||
+      err.message.includes("Reason: Already Verified")
+    ) {
+      console.log(
+        `Pilots contract already verified: '${rigsDeployment.pilotsAddress}'`
+      );
+    } else throw err;
+  }
 
   // Verify royalties contract
-  await run("verify:verify", {
-    address: rigsDeployment.royaltyContractAddress,
-    constructorArguments: [
-      rigsConfig.royaltyReceivers,
-      rigsConfig.royaltyReceiverShares,
-    ],
-  });
+  try {
+    await run("verify:verify", {
+      address: rigsDeployment.royaltyContractAddress,
+      constructorArguments: [
+        rigsConfig.royaltyReceivers,
+        rigsConfig.royaltyReceiverShares,
+      ],
+    });
+  } catch (err) {
+    if (
+      err.message === "Contract source code already verified" ||
+      err.message.includes("Reason: Already Verified")
+    ) {
+      console.log(
+        `Royalties contract already verified: '${rigsDeployment.royaltyContractAddress}'`
+      );
+    } else throw err;
+  }
 }
 
 main().catch((error) => {

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -1155,6 +1155,7 @@ describe("Rigs", function () {
             BigNumber.from(pilotTokenId)
           );
         let pilotReceipt = await tx.wait();
+        blockNumber = tx.blockNumber;
         // Check the pilot info
         pilotInfo = await rigs.pilotInfo(BigNumber.from(rigTokenId));
         expect(pilotInfo.status).to.equal(3);


### PR DESCRIPTION
The `TablelandRigPilots.sol` contract had a SQL issues that included a missing comma and incorrect `end_time` logic. This fixes these as well as makes the associated changes to the tests, plus, a small fix on the verification script (adds error handling with already verified contracts, which will otherwise halt the verification process).

There were also some slight logic changes when changing a pilot, which now creates a new session instead of morphing an existing trainer session into a "real pilot" session. Lastly, the mumbai contract pilot contract was upgraded to test these logic changes.