### PR TITLE
Scope CODEOWNERS to directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,13 @@
 # the repo. Unless a later match takes precedence.
 # By convention in @tablelandnetwork repos, the first listed
 # CODEOWNER is the repo DRI (directly responsible individual)
-*       @sanderpick @asutula @dtbuchholz @joewagner @datadanne
+* @sanderpick
+/animation_url/ @joewagner
+/artifacts/ @asutula
+/cmd/ @asutula
+/ethereum/ @dtbuchholz @sanderpick
+/garage/ @datadanne
+/pkg/ @asutula
+/viewer/ @asutula
+/.golangci.yml @asutula
+/go.* @asutula


### PR DESCRIPTION
This is a pretty simple approach, but should help get the right eyes on PRs and reduce noisy GH notifications for all of us. Feel free to suggest changes if you want/don't want to be code owner of a particular directory.

On a side note, doing this made me realize the Go project should be moved to a single sub directory. That might be coming in a PR next...