### PR TITLE
Better media parsing

### DIFF
--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -54,12 +54,14 @@
 
   .container {
     position: relative;
+    width: 100vh;
+    height: 100vh;
+    margin: 0 auto;
   }
 
   .rig-image {
     display: block;
-    width: 100vw;
-    height: 100vw;
+    width: 100%;
   }
 
   .badges-container {

--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -15,13 +15,15 @@
     {/each}
   </div>
   {#if data.pilot}
-    {#if data.pilot.type === "image"}
-      <img class="pilot" src={data.pilot.uri} alt="pilot" />
-    {:else}
-      <video class="pilot" playsinline autoplay muted loop>
-        <source src={data.pilot.uri}>
-      </video>
-    {/if}
+    <div class="pilot">
+      {#if data.pilot.type === "image"}
+        <img src={data.pilot.uri} alt="pilot" />
+      {:else}
+        <video playsinline autoplay muted loop>
+          <source src={data.pilot.uri}>
+        </video>
+      {/if}
+    </div>
     <span class="warning">Status: In-flight (not transferable).</span>
   {/if}
 </div>
@@ -55,7 +57,9 @@
   .container {
     position: relative;
     width: 100vh;
+    max-width: 100vw;
     height: 100vh;
+    max-height: 100vw;
     margin: 0 auto;
   }
 
@@ -87,12 +91,19 @@
     position: absolute;
     bottom: 0;
     right: 0;
-    max-height: 37%;
-    max-width: 25%;
-    min-width: 25%;
+    width: 25%;
+    height: 25%;
     border-top: 0.1875rem solid #101e1e;
     border-left: 0.1875rem solid #101e1e;
     border-radius: 0.1875rem 0 0 0;
+    background-color: #101e1e;
+  }
+
+  .pilot img, .pilot video {
+    object-fit: contain;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
   }
 
   .warning {

--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -58,7 +58,8 @@
 
   .rig-image {
     display: block;
-    width: 100%;
+    width: 100vw;
+    height: 100vw;
   }
 
   .badges-container {

--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -86,6 +86,7 @@
     right: 0;
     max-height: 37%;
     max-width: 25%;
+    min-width: 25%;
     border-top: 0.1875rem solid #101e1e;
     border-left: 0.1875rem solid #101e1e;
     border-radius: 0.1875rem 0 0 0;

--- a/ethereum/scripts/parkRigs.ts
+++ b/ethereum/scripts/parkRigs.ts
@@ -1,0 +1,33 @@
+import { ethers, network, rigsDeployment } from "hardhat";
+import { TablelandRigs } from "../typechain-types";
+
+async function main() {
+  console.log(`\nParking rigs on '${network.name}'...`);
+
+  // Get owner account
+  const [account] = await ethers.getSigners();
+  if (account.provider === undefined) {
+    throw Error("missing provider");
+  }
+
+  // Get contract address
+  if (rigsDeployment.contractAddress === "") {
+    throw Error(`no contractAddress entry for '${network.name}'`);
+  }
+  console.log(`Using address '${rigsDeployment.contractAddress}'`);
+
+  // Update mint phase
+  const rigs = (await ethers.getContractFactory("TablelandRigs")).attach(
+    rigsDeployment.contractAddress
+  ) as TablelandRigs;
+  const tx = await rigs.parkRigAsOwner([
+    /* rigs IDs to park here */
+  ]);
+  const receipt = await tx.wait();
+  console.log(`parked rigs with txn '${receipt.transactionHash}'`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
The alchemy NFT API responses seem to change based on some indexing. eg, a token with GIF media I was testing resulted in a response that had a gateway URI w/ an extension direct from the contract metadata. Rechecking this morning, looks like Alchemy indexed it and included the `format` param and a gateway link without an extension. That broke my parsing, resulting in showing the question mark image.

This changes the logic to use `format` if available and fallback to parsing the URI to determine if the media is an image or video. 

Also switch to using the indexed thumbnail if available. 