### PR TITLE
Animation url: Simplify pilot uri to only use images from the alchemy gateway or raw svg data

### DIFF
--- a/animation_url/src/routes/[slug]/+page.svelte
+++ b/animation_url/src/routes/[slug]/+page.svelte
@@ -16,13 +16,7 @@
   </div>
   {#if data.pilot}
     <div class="pilot">
-      {#if data.pilot.type === "image"}
-        <img src={data.pilot.uri} alt="pilot" />
-      {:else}
-        <video playsinline autoplay muted loop>
-          <source src={data.pilot.uri}>
-        </video>
-      {/if}
+      <img src={data.pilot.uri} alt="pilot" />
     </div>
     <span class="warning">Status: In-flight (not transferable).</span>
   {/if}

--- a/animation_url/src/routes/[slug]/+page.ts
+++ b/animation_url/src/routes/[slug]/+page.ts
@@ -47,26 +47,7 @@ export async function load({ url }) {
 
 type Pilot = {
   uri?: string;
-  type?: MediaType;
 };
-
-enum MediaType {
-  image = "image",
-  video = "video",
-}
-
-const mediaTypes = new Map([
-  ["jpg", MediaType.image],
-  ["jpeg", MediaType.image],
-  ["png", MediaType.image],
-  ["svg", MediaType.image],
-  ["gif", MediaType.image],
-  ["mp4", MediaType.video],
-  ["mov", MediaType.video],
-  ["ogv", MediaType.video],
-  ["webm", MediaType.video],
-  ["3gp", MediaType.video],
-]);
 
 const getPilot = async function (rigId: string): Promise<Pilot | undefined> {
   // Get the sessions where end_time is null, there should only ever be one of these
@@ -90,58 +71,13 @@ const getPilot = async function (rigId: string): Promise<Pilot | undefined> {
       session.pilot_id,
       NftTokenType.ERC721
     );
-    console.info("pilot token:", pilotToken);
 
-    if (pilotToken.media.length > 0) {
-      const media = pilotToken.media[0];
-      const pilot: Pilot = {
-        uri: encodeSVG(media.thumbnail || media.gateway || media.raw),
-      };
-      if (media.format) {
-        pilot.type = mediaTypes.get(media.format);
-      } else {
-        pilot.type = getMediaType(pilot.uri);
-      }
-      return pilot.type ? pilot : { uri: unknown, type: MediaType.image };
-    } else if (pilotToken.rawMetadata?.image_data) {
-      return {
-        uri: pilotToken.rawMetadata?.image_data,
-        type: MediaType.image,
-      };
-    } else if (pilotToken.rawMetadata?.svg_image_data) {
-      return {
-        uri: pilotToken.rawMetadata?.svg_image_data,
-        type: MediaType.image,
-      };
-    } else {
-      return { uri: unknown, type: MediaType.image };
-    }
+    const imageUrl = pilotToken?.media[0]?.gateway;
+    const rawSvg = pilotToken?.rawMetadata?.svg_image_data;
+
+    return { uri: imageUrl || rawSvg || unknown };
   }
 
   // else show trainer
-  return { uri: trainer, type: MediaType.image };
-};
-
-const getMediaType = function (uri?: string): MediaType | undefined {
-  if (!uri) {
-    return undefined;
-  }
-  if (uri.startsWith("data:image/")) {
-    return MediaType.image;
-  }
-  const parts = uri.split(".");
-  const extension = parts[parts.length - 1];
-  return mediaTypes.get(extension);
-};
-
-const encodeSVG = function (uri?: string): string | undefined {
-  if (!uri) {
-    return undefined;
-  }
-  if (uri.startsWith("data:image/svg+xml;utf8,")) {
-    const parts = uri.split("data:image/svg+xml;utf8,");
-    return "data:image/svg+xml;base64," + btoa(parts[1]);
-  } else {
-    return uri;
-  }
+  return { uri: trainer };
 };


### PR DESCRIPTION
This simplifies the image url calculation to work the same way it does in the garage app. This also fixes the issue reported on discord where moonbirds currently don't work, they use a regular centralized http app to return the metadata without a file extension in the url (like `https://live-metadata....app/1231`). I don't know if this will work with birds that are rendered on-chain though, the alchemy api still returns the old centralized metadata for all birds including those that have moved to on-chain. I created a ticket in the alchemy discord and asked why that is and how it will work once it is fixed, will follow up with the necessary changes once I hear back from them