### PR TITLE
Garage: add account and pilot stats to Dashboard

### DIFF
--- a/garage/src/App.tsx
+++ b/garage/src/App.tsx
@@ -97,6 +97,16 @@ const theme = extendTheme(
           orbitron: { fontFamily: "'Orbitron', sans-serif", fontWeight: 900 },
         },
       },
+      Tabs: {
+        variants: {
+          line: {
+            tab: {
+              color: "primary",
+              _selected: { color: "primary" },
+            },
+          },
+        },
+      },
       Table: {
         variants: {
           simple: {

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -193,7 +193,7 @@ export const useNFTCollectionSearch = (search: string) => {
   return data;
 };
 
-export const useNFTCollections = (contracts: string[]) => {
+export const useNFTCollections = (contracts?: string[]) => {
   const [data, setData] = useState<NFTCollectionsData>({
     isLoading: false,
     isError: false,
@@ -202,7 +202,7 @@ export const useNFTCollections = (contracts: string[]) => {
   useEffect(() => {
     let isCancelled = false;
 
-    if (!contracts.length) {
+    if (!contracts?.length) {
       setData({ isLoading: false, isError: false });
       return;
     }

--- a/garage/src/hooks/useRigStats.ts
+++ b/garage/src/hooks/useRigStats.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react";
-import { selectStats, selectAccountStats } from "../utils/queries";
+import {
+  selectStats,
+  selectAccountStats,
+  selectTopActivePilotCollections,
+  selectTopFtPilotCollections,
+} from "../utils/queries";
 import { useTablelandConnection } from "./useTablelandConnection";
 
 export interface Stat {
@@ -79,6 +84,66 @@ export const useAccountStats = (
       isCancelled = true;
     };
   }, [currentBlockNumber, address, setStats]);
+
+  return { stats };
+};
+
+export const useTopActivePilotCollections = () => {
+  const { connection: tableland } = useTablelandConnection();
+
+  const [stats, setStats] = useState<
+    { contractAddress: string; count: number }[]
+  >();
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    tableland.read(selectTopActivePilotCollections()).then((result) => {
+      if (isCancelled) return;
+
+      const data = result.rows.map(([contractAddress, count]) => ({
+        contractAddress,
+        count,
+      }));
+      setStats(data);
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [setStats]);
+
+  return { stats };
+};
+
+export const useTopFtPilotCollections = (currentBlockNumber?: number) => {
+  const { connection: tableland } = useTablelandConnection();
+
+  const [stats, setStats] = useState<
+    { contractAddress: string; ft: number }[]
+  >();
+
+  useEffect(() => {
+    if (!currentBlockNumber) return;
+
+    let isCancelled = false;
+
+    tableland
+      .read(selectTopFtPilotCollections(currentBlockNumber))
+      .then((result) => {
+        if (isCancelled) return;
+
+        const data = result.rows.map(([contractAddress, ft]) => ({
+          contractAddress,
+          ft,
+        }));
+        setStats(data);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [currentBlockNumber, setStats]);
 
   return { stats };
 };

--- a/garage/src/pages/Dashboard/modules/Stats.tsx
+++ b/garage/src/pages/Dashboard/modules/Stats.tsx
@@ -129,7 +129,7 @@ export const Stats = (props: React.ComponentProps<typeof Box>) => {
   return (
     <Flex direction="column" sx={{ height: "100%" }} {...props}>
       <Heading mb={4}>Stats</Heading>
-      <Tabs>
+      <Tabs variant="line">
         <TabList>
           <Tab>Global</Tab>
           <Tab>You</Tab>

--- a/garage/src/pages/Dashboard/modules/Stats.tsx
+++ b/garage/src/pages/Dashboard/modules/Stats.tsx
@@ -7,10 +7,15 @@ import {
   SimpleGrid,
   Spinner,
   Stack,
+  Tab,
+  Tabs,
+  TabList,
+  TabPanel,
+  TabPanels,
   Text,
 } from "@chakra-ui/react";
-import { useBlockNumber } from "wagmi";
-import { useStats } from "../../../hooks/useRigStats";
+import { useAccount, useBlockNumber } from "wagmi";
+import { useAccountStats, useStats, Stat } from "../../../hooks/useRigStats";
 import { prettyNumber } from "../../../utils/fmt";
 
 const StatItem = ({ name, value }: { name: string; value: number }) => {
@@ -35,28 +40,50 @@ const StatItem = ({ name, value }: { name: string; value: number }) => {
   );
 };
 
+const StatGrid = ({ stats }: { stats?: Stat[] }) => {
+  return (
+    <SimpleGrid minChildWidth="260px" gap={3}>
+      {stats &&
+        stats.map(({ name, value }) => {
+          return (
+            <GridItem key={name} bgColor="block">
+              <StatItem name={name} value={value} />
+            </GridItem>
+          );
+        })}
+      {!stats && (
+        <Flex justify="center">
+          <Spinner />
+        </Flex>
+      )}
+    </SimpleGrid>
+  );
+};
+
 export const Stats = (props: React.ComponentProps<typeof Box>) => {
+  const { address } = useAccount();
   const { data: currentBlockNumber } = useBlockNumber();
   const { stats } = useStats(currentBlockNumber);
+  const { stats: accountStats } = useAccountStats(currentBlockNumber, address);
 
   return (
     <Flex direction="column" sx={{ height: "100%" }} {...props}>
       <Heading mb={4}>Stats</Heading>
-      <SimpleGrid minChildWidth="260px" gap={3}>
-        {stats &&
-          stats.map(({ name, value }) => {
-            return (
-              <GridItem key={name} bgColor="block">
-                <StatItem name={name} value={value} />
-              </GridItem>
-            );
-          })}
-        {!stats && (
-          <Flex justify="center">
-            <Spinner />
-          </Flex>
-        )}
-      </SimpleGrid>
+      <Tabs>
+        <TabList>
+          <Tab>Global</Tab>
+          <Tab>You</Tab>
+        </TabList>
+
+        <TabPanels>
+          <TabPanel px={0}>
+            <StatGrid stats={stats} />
+          </TabPanel>
+          <TabPanel px={0}>
+            <StatGrid stats={accountStats} />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
     </Flex>
   );
 };

--- a/garage/src/pages/Dashboard/modules/Stats.tsx
+++ b/garage/src/pages/Dashboard/modules/Stats.tsx
@@ -1,13 +1,21 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   Box,
   Heading,
   Flex,
   GridItem,
+  VStack,
+  Image,
   SimpleGrid,
   Spinner,
   Stack,
   Tab,
+  Table,
+  Thead,
+  Tbody,
+  Th,
+  Tr,
+  Td,
   Tabs,
   TabList,
   TabPanel,
@@ -15,7 +23,14 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useAccount, useBlockNumber } from "wagmi";
-import { useAccountStats, useStats, Stat } from "../../../hooks/useRigStats";
+import {
+  useAccountStats,
+  useStats,
+  useTopActivePilotCollections,
+  useTopFtPilotCollections,
+  Stat,
+} from "../../../hooks/useRigStats";
+import { useNFTCollections, Collection } from "../../../hooks/useNFTs";
 import { prettyNumber } from "../../../utils/fmt";
 
 const StatItem = ({ name, value }: { name: string; value: number }) => {
@@ -60,11 +75,56 @@ const StatGrid = ({ stats }: { stats?: Stat[] }) => {
   );
 };
 
+const CollectionToplist = ({
+  stat,
+  data,
+}: {
+  stat: string;
+  data: { collection: Collection; stat: string | number }[];
+}) => {
+  return (
+    <Table>
+      <Thead>
+        <Tr>
+          <Th colSpan={2}>Collection</Th>
+          <Th isNumeric>{stat}</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {data?.slice(0, 10).map(({ collection, stat }, index) => {
+          return (
+            <Tr key={`pilot-${index}`}>
+              <Td width="30px" px={0}>
+                <Image src={collection?.imageUrl} width="30px" height="30px" />
+              </Td>
+              <Td>{collection?.name}</Td>
+              <Td isNumeric>{stat}</Td>
+            </Tr>
+          );
+        })}
+      </Tbody>
+    </Table>
+  );
+};
+
 export const Stats = (props: React.ComponentProps<typeof Box>) => {
   const { address } = useAccount();
   const { data: currentBlockNumber } = useBlockNumber();
   const { stats } = useStats(currentBlockNumber);
   const { stats: accountStats } = useAccountStats(currentBlockNumber, address);
+  const { stats: pilotStats } = useTopActivePilotCollections();
+  const { stats: ftStats } = useTopFtPilotCollections(currentBlockNumber);
+
+  const contracts = useMemo(
+    () => pilotStats?.slice(0, 10).map((v) => v.contractAddress),
+    [pilotStats]
+  );
+  const { collections } = useNFTCollections(contracts);
+  const collectionLookup = useMemo(() => {
+    return Object.fromEntries(
+      collections?.map((v) => [v.contractAddress.toLowerCase(), v]) || []
+    );
+  }, [collections]);
 
   return (
     <Flex direction="column" sx={{ height: "100%" }} {...props}>
@@ -73,6 +133,7 @@ export const Stats = (props: React.ComponentProps<typeof Box>) => {
         <TabList>
           <Tab>Global</Tab>
           <Tab>You</Tab>
+          <Tab>Pilots</Tab>
         </TabList>
 
         <TabPanels>
@@ -81,6 +142,43 @@ export const Stats = (props: React.ComponentProps<typeof Box>) => {
           </TabPanel>
           <TabPanel px={0}>
             <StatGrid stats={accountStats} />
+          </TabPanel>
+          <TabPanel fontSize="0.8em" px={0}>
+            <Flex
+              width="100%"
+              gap={8}
+              pt={2}
+              direction={{ base: "column", md: "row" }}
+            >
+              <VStack flexGrow="1" align="start">
+                <Heading>Top collections</Heading>
+                {pilotStats && (
+                  <CollectionToplist
+                    stat="Num. pilots"
+                    data={pilotStats
+                      .slice(0, 10)
+                      .map(({ contractAddress, count }) => {
+                        const collection = collectionLookup[contractAddress];
+                        return { collection, stat: count };
+                      })}
+                  />
+                )}
+              </VStack>
+              <VStack flexGrow="1" align="start">
+                <Heading>Most FT earned</Heading>
+                {ftStats && (
+                  <CollectionToplist
+                    stat="FT"
+                    data={ftStats
+                      .slice(0, 10)
+                      .map(({ contractAddress, ft }) => {
+                        const collection = collectionLookup[contractAddress];
+                        return { collection, stat: prettyNumber(ft) };
+                      })}
+                  />
+                )}
+              </VStack>
+            </Flex>
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/garage/src/utils/queries.ts
+++ b/garage/src/utils/queries.ts
@@ -196,6 +196,25 @@ export const selectAccountStats = (blockNumber: number, address: string): string
   LIMIT 1;`;
 };
 
+export const selectTopActivePilotCollections = (): string => {
+  return `
+  SELECT pilot_contract, count(*) as count
+  FROM ${pilotSessionsTable}
+  WHERE end_time IS NULL AND pilot_contract IS NOT NULL
+  GROUP BY pilot_contract
+  ORDER BY count DESC`;
+};
+
+
+export const selectTopFtPilotCollections = (blockNumber: number): string => {
+  return `
+  SELECT pilot_contract, sum(coalesce(end_time, ${blockNumber}) - start_time) as ft
+  FROM ${pilotSessionsTable}
+  WHERE pilot_contract IS NOT NULL
+  GROUP BY pilot_contract
+  ORDER BY ft DESC`;
+};
+
 export const selectActivePilotSessionsForPilots = (
   pilots: { contract: string; tokenId: string }[]
 ): string => {


### PR DESCRIPTION
Adds tabs to the Stats section on the dashboard, and adds two new tabs with account stats & pilot stats:
![image](https://user-images.githubusercontent.com/656107/208422371-823be11a-b54b-42f3-ac90-ec70d04fbb11.png)
![image](https://user-images.githubusercontent.com/656107/208422385-8def9836-4e4c-4fe8-a5b3-f2dc4b980b5e.png)

This isn't something we have on the current roadmap but it was the top suggestion from the community so it felt right to get that in now :)

@dtbuchholz @sanderpick any suggestions on what to use as labels for the two tables? 