### PR TITLE
Garage: Update rig details page with links to opensea and owner profile

### DIFF
--- a/garage/src/App.tsx
+++ b/garage/src/App.tsx
@@ -79,6 +79,16 @@ const theme = extendTheme(
           borderColor: "#1E3535 !important",
           borderTop: "var(--chakra-borders-1px)",
         },
+        a: {
+          ":not(.chakra-button)": {
+            textDecorationLine: "underline",
+            textUnderlinePosition: "under",
+            textDecorationColor: "inactive",
+          },
+          ":hover": {
+            textDecorationColor: "inherit",
+          },
+        },
       },
     },
     components: {

--- a/garage/src/env.ts
+++ b/garage/src/env.ts
@@ -12,6 +12,10 @@ export const blockExplorerBaseUrl = isDevelopment
   ? "https://mumbai.polygonscan.com"
   : "https://etherscan.io";
 
+export const openseaBaseUrl = isDevelopment
+  ? "https://testnets.opensea.io/assets/mumbai"
+  : "https://opensea.io/assets/ethereum";
+
 export const deployment = isDevelopment
   ? deployments["polygon-mumbai"]
   : deployments.ethereum;

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -92,6 +92,28 @@ export const useNFTs = (input?: { contract: string; tokenId: string }[]) => {
   return { nfts };
 };
 
+export const useNFTOwner = (contract?: string, tokenId?: string) => {
+  const [owner, setOwner] = useState<string>();
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    if (!contract || !tokenId) return;
+
+    alchemy.nft.getOwnersForNft(contract, tokenId).then((v) => {
+      if (isCancelled) return;
+
+      setOwner(v.owners?.[0]);
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [contract, tokenId, setOwner]);
+
+  return owner;
+};
+
 interface OwnedNFTsFilter {
   contracts?: string[];
 }

--- a/garage/src/pages/Dashboard/modules/Activity.tsx
+++ b/garage/src/pages/Dashboard/modules/Activity.tsx
@@ -28,12 +28,6 @@ const getPilotedTitle = (
   return `Piloted ${collectionName} #${tokenId}`;
 };
 
-const UnderlineLink = styled(Link)`
-  &:hover {
-    text-decoration: underline;
-  }
-`;
-
 export const Activity = (props: React.ComponentProps<typeof Box>) => {
   const { events } = useRigsActivity();
   const { p = "8px", ...otherProps } = props;
@@ -98,9 +92,7 @@ export const Activity = (props: React.ComponentProps<typeof Box>) => {
                     </Link>
                   </Td>
                   <Td width="60px">
-                    <UnderlineLink
-                      to={`/rigs/${rigId}`}
-                    >{`#${rigId}`}</UnderlineLink>
+                    <Link to={`/rigs/${rigId}`}>{`#${rigId}`}</Link>
                   </Td>
                   <Td
                     pr={p}

--- a/garage/src/pages/OwnerDetails/modules/Activity.tsx
+++ b/garage/src/pages/OwnerDetails/modules/Activity.tsx
@@ -82,7 +82,7 @@ export const ActivityLog = ({ events, p, ...props }: ActivityLogProps) => {
                     />
                   </Td>
                   <Td>
-                    <Link to={`/rigs/${rigId}`}>Rig #{rigId}</Link>
+                    <Link to={`/rigs/${rigId}`}>#{rigId}</Link>
                   </Td>
                   <Td pr={p} isNumeric>
                     {title}

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -1,5 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Box, Flex, Grid, GridItem, Spinner, VStack } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  HStack,
+  Show,
+  Spinner,
+  VStack,
+} from "@chakra-ui/react";
 import { useParams } from "react-router-dom";
 import { useAccount, useBlockNumber } from "wagmi";
 import { useGlobalFlyParkModals } from "../../components/GlobalFlyParkModals";
@@ -13,7 +23,9 @@ import { FlightLog } from "./modules/FlightLog";
 import { Pilots } from "./modules/Pilots";
 import { RigAttributes } from "./modules/RigAttributes";
 import { findNFT } from "../../utils/nfts";
+import { prettyNumber } from "../../utils/fmt";
 import { sleep, runUntilConditionMet } from "../../utils/async";
+import { RigWithPilots } from "../../types";
 
 const GRID_GAP = 4;
 
@@ -22,6 +34,36 @@ const MODULE_PROPS = {
   p: 8,
   bgColor: "paper",
   overflow: "hidden",
+};
+
+const RigHeader = ({
+  rig,
+  currentBlockNumber,
+}: {
+  rig: RigWithPilots;
+  currentBlockNumber?: number;
+}) => {
+  const totalFlightTime = rig.pilotSessions.reduce(
+    (acc, { startTime, endTime }) => {
+      return (
+        acc +
+        Math.max((endTime ?? currentBlockNumber ?? startTime) - startTime, 0)
+      );
+    },
+    0
+  );
+
+  return (
+    <Box {...MODULE_PROPS}>
+      <HStack justify="space-between" align="baseline" sx={{ width: "100%" }}>
+        <Heading size="xl">Rig {`#${rig.id}`}</Heading>
+      <Heading size="sm">
+        {rig.currentPilot ? "In-flight" : "Parked"}
+        {` (${prettyNumber(totalFlightTime)} FT)`}
+      </Heading>
+      </HStack>
+    </Box>
+  );
 };
 
 export const RigDetails = () => {
@@ -125,6 +167,11 @@ export const RigDetails = () => {
             </GridItem>
             <GridItem>
               <VStack align="stretch" spacing={GRID_GAP}>
+                <RigHeader
+                  {...MODULE_PROPS}
+                  rig={rig}
+                  currentBlockNumber={currentBlockNumber}
+                />
                 <Pilots
                   rig={rig}
                   nfts={nfts}

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -6,6 +6,8 @@ import {
   GridItem,
   Heading,
   HStack,
+  Image,
+  Link,
   Show,
   Spinner,
   VStack,
@@ -25,7 +27,10 @@ import { RigAttributes } from "./modules/RigAttributes";
 import { findNFT } from "../../utils/nfts";
 import { prettyNumber } from "../../utils/fmt";
 import { sleep, runUntilConditionMet } from "../../utils/async";
+import { contractAddress } from "../../contract";
+import { openseaBaseUrl } from "../../env";
 import { RigWithPilots } from "../../types";
+import openseaMark from "../../assets/opensea-mark.svg";
 
 const GRID_GAP = 4;
 
@@ -57,6 +62,14 @@ const RigHeader = ({
     <Box {...MODULE_PROPS}>
       <HStack justify="space-between" align="baseline" sx={{ width: "100%" }}>
         <Heading size="xl">Rig {`#${rig.id}`}</Heading>
+        <Link
+          href={`${openseaBaseUrl}/${contractAddress}/${rig.id}`}
+          title={`View Rig #${rig.id} on OpenSea`}
+          isExternal
+        >
+          <Image src={openseaMark} />
+        </Link>
+      </HStack>
       <Heading size="sm">
         {rig.currentPilot ? "In-flight" : "Parked"}
         {` (${prettyNumber(totalFlightTime)} FT)`}

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -10,15 +10,16 @@ import {
   Link,
   Show,
   Spinner,
+  Text,
   VStack,
 } from "@chakra-ui/react";
-import { useParams } from "react-router-dom";
+import { useParams, Link as RouterLink } from "react-router-dom";
 import { useAccount, useBlockNumber } from "wagmi";
 import { useGlobalFlyParkModals } from "../../components/GlobalFlyParkModals";
 import { useOwnedRigs } from "../../hooks/useOwnedRigs";
 import { useTablelandConnection } from "../../hooks/useTablelandConnection";
 import { useRig } from "../../hooks/useRig";
-import { useNFTs } from "../../hooks/useNFTs";
+import { useNFTs, useNFTOwner } from "../../hooks/useNFTs";
 import { TOPBAR_HEIGHT } from "../../Topbar";
 import { RigDisplay } from "../../components/RigDisplay";
 import { FlightLog } from "./modules/FlightLog";
@@ -43,9 +44,11 @@ const MODULE_PROPS = {
 
 const RigHeader = ({
   rig,
+  owner,
   currentBlockNumber,
 }: {
   rig: RigWithPilots;
+  owner?: string;
   currentBlockNumber?: number;
 }) => {
   const totalFlightTime = rig.pilotSessions.reduce(
@@ -74,6 +77,13 @@ const RigHeader = ({
         {rig.currentPilot ? "In-flight" : "Parked"}
         {` (${prettyNumber(totalFlightTime)} FT)`}
       </Heading>
+      <HStack pt={8}>
+        <Text>
+          Owned by{" "}
+          <RouterLink to={`/owner/${owner}`} style={{ fontWeight: "bold" }}>
+            {owner}
+          </RouterLink>
+        </Text>
       </HStack>
     </Box>
   );
@@ -86,6 +96,7 @@ export const RigDetails = () => {
   const { rig, refresh } = useRig(id || "", currentBlockNumber);
   const { connection: tableland } = useTablelandConnection();
   const { rigs } = useOwnedRigs(address, currentBlockNumber);
+  const owner = useNFTOwner(contractAddress, id);
   const pilots = useMemo(() => {
     return rig?.pilotSessions.filter((v) => v.contract);
   }, [rig]);
@@ -183,6 +194,7 @@ export const RigDetails = () => {
                 <RigHeader
                   {...MODULE_PROPS}
                   rig={rig}
+                  owner={owner}
                   currentBlockNumber={currentBlockNumber}
                 />
                 <Pilots

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -42,15 +42,18 @@ const MODULE_PROPS = {
   overflow: "hidden",
 };
 
+type RigHeaderProps = React.ComponentProps<typeof Box> & {
+  rig: RigWithPilots;
+  owner?: string;
+  currentBlockNumber?: number;
+};
+
 const RigHeader = ({
   rig,
   owner,
   currentBlockNumber,
-}: {
-  rig: RigWithPilots;
-  owner?: string;
-  currentBlockNumber?: number;
-}) => {
+  ...props
+}: RigHeaderProps) => {
   const totalFlightTime = rig.pilotSessions.reduce(
     (acc, { startTime, endTime }) => {
       return (
@@ -62,7 +65,7 @@ const RigHeader = ({
   );
 
   return (
-    <Box {...MODULE_PROPS}>
+    <Box {...props}>
       <HStack justify="space-between" align="baseline" sx={{ width: "100%" }}>
         <Heading size="xl">Rig {`#${rig.id}`}</Heading>
         <Link

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -174,6 +174,14 @@ export const RigDetails = () => {
           <>
             <GridItem>
               <VStack align="stretch" spacing={GRID_GAP}>
+                <Show below="md">
+                  <RigHeader
+                    {...MODULE_PROPS}
+                    rig={rig}
+                    owner={owner}
+                    currentBlockNumber={currentBlockNumber}
+                  />
+                </Show>
                 <Box p={4} bgColor="paper" borderRadius="3px">
                   <RigDisplay
                     border={1}
@@ -191,12 +199,14 @@ export const RigDetails = () => {
             </GridItem>
             <GridItem>
               <VStack align="stretch" spacing={GRID_GAP}>
-                <RigHeader
-                  {...MODULE_PROPS}
-                  rig={rig}
-                  owner={owner}
-                  currentBlockNumber={currentBlockNumber}
-                />
+                <Show above="md">
+                  <RigHeader
+                    {...MODULE_PROPS}
+                    rig={rig}
+                    owner={owner}
+                    currentBlockNumber={currentBlockNumber}
+                  />
+                </Show>
                 <Pilots
                   rig={rig}
                   nfts={nfts}

--- a/garage/src/pages/RigDetails/modules/Pilots.tsx
+++ b/garage/src/pages/RigDetails/modules/Pilots.tsx
@@ -82,25 +82,9 @@ export const Pilots = ({
   }, [rig, refetch]);
   const pilots = getPilots(rig, nfts, blockNumber);
 
-  const totalFlightTime = pilots.reduce(
-    (acc, { flightTime }) => acc + flightTime,
-    0
-  );
-
   return (
     <VStack align="stretch" spacing={4} pt={p} {...props}>
-      <HStack
-        px={p}
-        justify="space-between"
-        align="baseline"
-        sx={{ width: "100%" }}
-      >
-        <Heading size="xl">Rig {`#${rig.id}`}</Heading>
-        <Heading size="sm">
-          {rig.currentPilot ? "In-flight" : "Parked"}
-          {` (${prettyNumber(totalFlightTime)} FT)`}
-        </Heading>
-      </HStack>
+      <Heading px={p}>Pilots</Heading>
       <Table>
         <Thead>
           <Tr>


### PR DESCRIPTION
### Changes

- Updates all text links on the page to use `text-decoration: underline`
- Moves the "rig header" on /rigs/:id into a separate box/module
- Adds a link to OpenSea to the header on /rigs/:id
- Adds a link to the owner profile to the header on /rigs/:id

Closes https://github.com/tablelandnetwork/rigs/issues/392
 
### Rig details page updates:
<img width="2117" alt="image" src="https://user-images.githubusercontent.com/656107/210806476-d1a773fb-41bf-40b3-ae24-02bb7649d025.png">

### Rig details page updates, mobile layout:
<img width="2117" alt="image" src="https://user-images.githubusercontent.com/656107/210806506-b0f9ecf1-9a9a-4dfe-8c73-40abb9f8e26b.png">

### All text links are now underlined:
<img width="2117" alt="image" src="https://user-images.githubusercontent.com/656107/210807018-dd99ff59-06b6-433c-a990-c4a141ddde25.png">

