### PR TITLE
Garage: Fix park modal to check if training is complete before warning about it

### DIFF
--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -164,6 +164,8 @@ export const ParkRigsModal = ({
     hash: contractWrite.data?.hash,
   });
 
+  const hasNotCompletedTraining = rigs.some((v) => !v.isTrained);
+
   useEffect(() => {
     if (!isOpen) reset();
   }, [isOpen, reset]);
@@ -180,11 +182,13 @@ export const ParkRigsModal = ({
         <ModalHeader>Park {pluralize("Rig", rigs)}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <Text>
-            Training isn't complete! Be aware that your Rig will lose all of its
-            FT if you park now.
-          </Text>
-          <Text mt={4}>Parked Rigs can be sold or transferred.</Text>
+          {hasNotCompletedTraining && (
+            <Text mb={4}>
+              Training isn't complete! Be aware that your{" "}
+              {pluralize("Rig", rigs)} will lose all of its FT if you park now.
+            </Text>
+          )}
+          <Text>Parked Rigs can be sold or transferred.</Text>
           <Text mt={4} sx={{ fontStyle: "italic" }}>
             Parking requires an on-chain transaction. When you click the Park
             button below your wallet will request that you sign a transaction


### PR DESCRIPTION
Fixes the park modal so that it doesn't always warn about training not being complete. The modal looks kind of empty without that text, if you want to add some other text if the rig is trained feel free to @sanderpick 

<img width="1792" alt="image" src="https://user-images.githubusercontent.com/656107/220457073-9ac063f3-7aac-4516-9e87-b08539bf9cd0.png">

Closes https://github.com/tablelandnetwork/rigs/issues/646