### PR TITLE
Garage: Show FT under each rig on dashboard

### DIFF
--- a/garage/src/hooks/useOwnedRigs.ts
+++ b/garage/src/hooks/useOwnedRigs.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Rig, isValidAddress } from "../types";
+import { RigWithPilots, isValidAddress } from "../types";
 import { useContractRead } from "wagmi";
 import { useTablelandConnection } from "./useTablelandConnection";
 import { selectRigs } from "../utils/queries";
@@ -19,7 +19,7 @@ export const useOwnedRigs = (address?: string) => {
     enabled: !!address,
   });
 
-  const [rigs, setRigs] = useState<Rig[]>();
+  const [rigs, setRigs] = useState<RigWithPilots[]>();
   const [shouldRefresh, setShouldRefresh] = useState({});
 
   const refresh = useCallback(() => {
@@ -32,7 +32,7 @@ export const useOwnedRigs = (address?: string) => {
       const ids = data.map((bn) => bn.toString());
 
       db.prepare(selectRigs(ids))
-        .all<Rig>()
+        .all<RigWithPilots>()
         .then(({ results }) => {
           if (!isCancelled) setRigs(results);
         });

--- a/garage/src/utils/queries.ts
+++ b/garage/src/utils/queries.ts
@@ -43,7 +43,19 @@ export const selectRigs = (ids: string[]): string => {
         OR
         (session.end_time - session.start_time) >= ${PILOT_TRAINING_DURATION}
       )
-    ) AS "isTrained"
+    ) AS "isTrained",
+    (
+      SELECT
+        json_group_array(json_object(
+          'contract', pilot_contract,
+          'tokenId', cast(pilot_id as text),
+          'owner', owner,
+          'startTime', start_time,
+          'endTime', end_time
+        ))
+      FROM ${pilotSessionsTable} AS session
+      WHERE session.rig_id = attributes.rig_id
+    ) AS "pilotSessions"
   FROM ${attributesTable} AS attributes
   JOIN ${lookupsTable}
   WHERE rig_id IN ('${ids.join("', '")}')


### PR DESCRIPTION
Updates the dashboard to use a ✈️ to indicate if a rig is in-flight, and replaces the in-flight text with total FT earned:
![image](https://user-images.githubusercontent.com/656107/221905745-cf429765-1c1b-4b08-965f-e299cc63f837.png)
instead of
![image](https://user-images.githubusercontent.com/656107/221906185-33720bf0-77eb-494c-8163-0961d13d333d.png)

I tried loading the dashboard for the largest holder (`0x6CaB818DAaF4040476E2489A7ED29Ca685aD0623`) and the query still loads fast enough!

Closes https://github.com/tablelandnetwork/rigs/issues/399