### PR TITLE
Use UNION to extend metadata attributes

### DIFF
--- a/ethereum/helpers/uris.ts
+++ b/ethereum/helpers/uris.ts
@@ -1,72 +1,90 @@
-export function getURITemplate(
+import { init, __wasm } from "@tableland/sqlparser";
+
+export async function normalize(sql: string) {
+  if (__wasm == null) {
+    await init();
+  }
+  return (await globalThis.sqlparser.normalize(sql)).statements[0];
+}
+
+export async function getURITemplate(
   tablelandHost: string,
   attributesTable: string,
   lookupsTable: string,
   pilotsTable: string,
   displayAttributes: boolean
-): string[] {
+): Promise<string[]> {
   if (!displayAttributes) {
     const uri =
       tablelandHost +
-      "/query?extract=true&unwrap=true&s=" +
+      "/api/v1/query?extract=true&unwrap=true&statement=" +
       encodeURIComponent(
-        `select json_object(
-          'name','Rig #'||rig_id,
-          'external_url','https://garage.tableland.xyz/rigs/'||rig_id,
-          'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,
-          'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,
-          'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,
-          'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,
-          'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,
-          'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,
-          'animation_url',animation_base_url||rig_id||'.html',
-          'attributes',json_array(
+        await normalize(
+          `select 
             json_object(
-              'trait_type','status',
-              'value','pre-reveal'
+              'name','Rig #'||rig_id,
+              'external_url','https://garage.tableland.xyz/rigs/'||rig_id,
+              'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,
+              'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,
+              'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,
+              'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,
+              'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,
+              'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,
+              'animation_url',animation_base_url||rig_id||'.html',
+              'attributes',json_array(
+                json_object(
+                  'trait_type','status',
+                  'value','pre-reveal'
+                )
+              )
             )
-          )
+          from
+            ${attributesTable}
+            join ${lookupsTable}
+          where rig_id=ID
+          group by rig_id;`
         )
-        from ${attributesTable} join ${lookupsTable}
-        where rig_id=ID
-        group by rig_id;`.replace(/(\r\n|\n|\r|\s\s+)/gm, "")
       );
     return uri.split("ID");
   } else {
     const uri =
       tablelandHost +
-      "/query?extract=true&unwrap=true&s=" +
+      "/api/v1/query?extract=true&unwrap=true&statement=" +
       encodeURIComponent(
-        `select json_object(
-          'name','Rig #'||rig_id,
-          'external_url','https://garage.tableland.xyz/rigs/'||rig_id,
-          'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,
-          'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,
-          'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,
-          'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,
-          'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,
-          'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,
-          'animation_url',animation_base_url||rig_id||'.html',
-          'attributes', json_group_array(
-            json_object('display_type',display_type,'trait_type',trait_type,'value',value)
-          )
+        await normalize(
+          `select
+            json_object(
+              'name','Rig #'||rig_id,
+              'external_url','https://garage.tableland.xyz/rigs/'||rig_id,
+              'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,
+              'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,
+              'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,
+              'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,
+              'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,
+              'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,
+              'animation_url',animation_base_url||rig_id||'.html',
+              'attributes', json_group_array(
+                json_object('display_type',display_type,'trait_type',trait_type,'value',value)
+              )
+            )
+          from 
+            (
+              select *
+              from ${attributesTable}
+              union
+              select
+                a.rig_id,
+                'string' display_type,
+                'Garage Status' trait_type,
+                case when start_time is null then 'parked' else 'in-flight' end value
+              from
+                ${attributesTable} a
+                left join (select * from ${pilotsTable} where end_time is null) s on a.rig_id = s.rig_id
+            )
+            join ${lookupsTable}
+          where rig_id=ID
+          group by rig_id;`
         )
-        from (
-          select *
-          from ${attributesTable}
-          union
-          select
-            a.rig_id,
-            'string' display_type,
-            'Garage Status' trait_type,
-            case when start_time is null then 'parked' else 'in-flight' end value
-          from
-            ${attributesTable} a
-            left join (select * from ${pilotsTable} where end_time is null) s on a.rig_id = s.rig_id
-        )
-        join ${lookupsTable}
-        where rig_id=ID
-        group by rig_id;`.replace(/(\r\n|\n|\r|\s\s+)/gm, "")
       );
     return uri.split("ID");
   }

--- a/ethereum/helpers/uris.ts
+++ b/ethereum/helpers/uris.ts
@@ -17,7 +17,7 @@ export async function getURITemplate(
   if (!displayAttributes) {
     const uri =
       tablelandHost +
-      "/api/v1/query?extract=true&unwrap=true&statement=" +
+      "/api/v1/query?format=objects&extract=true&unwrap=true&statement=" +
       encodeURIComponent(
         await normalize(
           `select 
@@ -49,7 +49,7 @@ export async function getURITemplate(
   } else {
     const uri =
       tablelandHost +
-      "/api/v1/query?extract=true&unwrap=true&statement=" +
+      "/api/v1/query?format=objects&extract=true&unwrap=true&statement=" +
       encodeURIComponent(
         await normalize(
           `select

--- a/ethereum/scripts/setURITemplate.ts
+++ b/ethereum/scripts/setURITemplate.ts
@@ -32,7 +32,7 @@ async function main() {
   const rigs = (await ethers.getContractFactory("TablelandRigs")).attach(
     rigsDeployment.contractAddress
   ) as TablelandRigs;
-  const uriTemplate = getURITemplate(
+  const uriTemplate = await getURITemplate(
     rigsDeployment.tablelandHost,
     rigsDeployment.attributesTable,
     rigsDeployment.lookupsTable,

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -541,9 +541,11 @@ describe("Rigs", function () {
       );
       const uri = new URL(uriTemplate.join("1"));
       const statement = uri.searchParams.get("statement");
+      /* eslint-disable no-unused-expressions */
+      expect(statement).not.to.be.null;
       // normalizing the statement checks that it is valid SQL, will throw
       // an error if it isn't
-      const normalizedStatement = await normalize(statement);
+      const normalizedStatement = await normalize(statement!);
       expect(normalizedStatement).contains("pre-reveal");
     });
 
@@ -559,11 +561,13 @@ describe("Rigs", function () {
         table3,
         true
       );
-      const uri = uriTemplate.join("1");
-      const uriParts = uri.split("statement=");
-      expect(uriParts.length).to.equal(2);
-      const statement = decodeURIComponent(uriParts[1]);
-      const normalizedStatement = await normalize(statement);
+      const uri = new URL(uriTemplate.join("1"));
+      const statement = uri.searchParams.get("statement");
+      /* eslint-disable no-unused-expressions */
+      expect(statement).not.to.be.null;
+      // normalizing the statement checks that it is valid SQL, will throw
+      // an error if it isn't
+      const normalizedStatement = await normalize(statement!);
       expect(normalizedStatement).contains("Garage Status");
     });
 

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -7,7 +7,7 @@ import { BigNumber, utils } from "ethers";
 import { ethers, network, upgrades } from "hardhat";
 import { MerkleTree } from "merkletreejs";
 import { AllowList, buildTree, hashEntry } from "../helpers/allowlist";
-import { getURITemplate } from "../helpers/uris";
+import { getURITemplate, normalize } from "../helpers/uris";
 import {
   PaymentSplitter,
   TablelandRigs,
@@ -532,16 +532,19 @@ describe("Rigs", function () {
       const table1 = "table1";
       const table2 = "table2";
       const table3 = "table3";
-      const uri = getURITemplate(tablelandHost, table1, table2, table3, false);
-      const part0 =
-        tablelandHost +
-        "/query?extract=true&unwrap=true&s=" +
-        encodeURIComponent(
-          `select json_object('name','Rig #'||rig_id,'external_url','https://garage.tableland.xyz/rigs/'||rig_id,'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,'animation_url',animation_base_url||rig_id||'.html','attributes',json_array(json_object('trait_type','status','value','pre-reveal'))) from table1 join table2 where rig_id=`
-        );
-      expect(uri[0]).to.equal(part0);
-      const part1 = encodeURIComponent(" group by rig_id;");
-      expect(uri[1]).to.equal(part1);
+      const uriTemplate = await getURITemplate(
+        tablelandHost,
+        table1,
+        table2,
+        table3,
+        false
+      );
+      const uri = uriTemplate.join("1");
+      const uriParts = uri.split("statement=");
+      expect(uriParts.length).to.equal(2);
+      const statement = decodeURIComponent(uriParts[1]);
+      const normalizedStatement = await normalize(statement);
+      expect(normalizedStatement).contains("pre-reveal");
     });
 
     it("Should have final metadata if attributeTable", async function () {
@@ -549,24 +552,19 @@ describe("Rigs", function () {
       const table1 = "table1";
       const table2 = "table2";
       const table3 = "table3";
-      const uri = getURITemplate(tablelandHost, table1, table2, table3, true);
-      const part0 =
-        tablelandHost +
-        "/query?extract=true&unwrap=true&s=" +
-        encodeURIComponent(
-          `select json_object('name','Rig #'||rig_id,'external_url','https://garage.tableland.xyz/rigs/'||rig_id,'image','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_name,'image_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_full_alpha_name,'image_medium','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_name,'image_medium_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_medium_alpha_name,'thumb','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_name,'thumb_alpha','ipfs://'||renders_cid||'/'||rig_id||'/'||image_thumb_alpha_name,'animation_url',animation_base_url||rig_id||'.html','attributes',json_insert((select json_group_array(json_object('display_type',display_type,'trait_type',trait_type,'value',value))from table1 where rig_id=`
-        );
-      expect(uri[0]).to.equal(part0);
-      const part1 = encodeURIComponent(
-        " group by rig_id),'$[#]',json_object('display_type','string','trait_type','Garage Status','value',coalesce((select coalesce(end_time, 'in-flight') from table3 where rig_id="
+      const uriTemplate = await getURITemplate(
+        tablelandHost,
+        table1,
+        table2,
+        table3,
+        true
       );
-      expect(uri[1]).to.equal(part1);
-      const part2 = encodeURIComponent(
-        " and end_time is null),'parked')))) from table1 join table2 where rig_id="
-      );
-      expect(uri[2]).to.equal(part2);
-      const part3 = encodeURIComponent(" group by rig_id;");
-      expect(uri[3]).to.equal(part3);
+      const uri = uriTemplate.join("1");
+      const uriParts = uri.split("statement=");
+      expect(uriParts.length).to.equal(2);
+      const statement = decodeURIComponent(uriParts[1]);
+      const normalizedStatement = await normalize(statement);
+      expect(normalizedStatement).contains("Garage Status");
     });
 
     it("Should not return token URI for non-existent token", async function () {

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -539,10 +539,10 @@ describe("Rigs", function () {
         table3,
         false
       );
-      const uri = uriTemplate.join("1");
-      const uriParts = uri.split("statement=");
-      expect(uriParts.length).to.equal(2);
-      const statement = decodeURIComponent(uriParts[1]);
+      const uri = new URL(uriTemplate.join("1"));
+      const statement = uri.searchParams.get("statement");
+      // normalizing the statement checks that it is valid SQL, will throw
+      // an error if it isn't
       const normalizedStatement = await normalize(statement);
       expect(normalizedStatement).contains("pre-reveal");
     });


### PR DESCRIPTION
When doing some recent work to extend Rigs metadata with Filecoin deal information, I was finding the existing metadata sql query very difficult to further extend since it had already been extended to support Garage status by using the `json_insert` SQLite function. Felt like there must be a better way that supports further metadata extensions without further complicating our use of SQLite JSON functions. Spent a while figuring it out, and landed on this. This query design fits nicely with the to-be-created Filecoin deals table and is overall just easier to read and understand.