### PR TITLE
feat: add EIP4906 metadata refresh

### DIFF
--- a/ethereum/.openzeppelin/polygon-mumbai.json
+++ b/ethereum/.openzeppelin/polygon-mumbai.json
@@ -5945,6 +5945,301 @@
           }
         }
       }
+    },
+    "627b9d62f97125df9b4af4fff4c29ca6553214dab96a8dabd12a523af2e08030": {
+      "address": "0x5Cc6f308381994F35c580eD049CAfCB684436736",
+      "txHash": "0x425d462ee500826b44e364edd2b1b9c11ad16f0319845e83feb23e3a4ff80a06",
+      "layout": {
+        "storage": [
+          {
+            "label": "_uriParts",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_string_storage)dyn_storage",
+            "contract": "URITemplate",
+            "src": "contracts/utils/URITemplate.sol:13"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "1",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_defaultRoyaltyInfo",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(RoyaltyInfo)1157_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:36"
+          },
+          {
+            "label": "_tokenRoyaltyInfo",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)1157_storage)",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:123"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "352",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "maxSupply",
+            "offset": 0,
+            "slot": "402",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:34"
+          },
+          {
+            "label": "mintPrice",
+            "offset": 0,
+            "slot": "403",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:37"
+          },
+          {
+            "label": "beneficiary",
+            "offset": 0,
+            "slot": "404",
+            "type": "t_address_payable",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:40"
+          },
+          {
+            "label": "allowlistRoot",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:43"
+          },
+          {
+            "label": "waitlistRoot",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:46"
+          },
+          {
+            "label": "mintPhase",
+            "offset": 0,
+            "slot": "407",
+            "type": "t_enum(MintPhase)7987",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:49"
+          },
+          {
+            "label": "_contractInfoURI",
+            "offset": 0,
+            "slot": "408",
+            "type": "t_string_storage",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:52"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "409",
+            "type": "t_contract(ITablelandRigPilots)7964",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:55"
+          },
+          {
+            "label": "_allowTransferWhileFlying",
+            "offset": 20,
+            "slot": "409",
+            "type": "t_bool",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:58"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_address_payable": {
+            "label": "address payable",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_string_storage)dyn_storage": {
+            "label": "string[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ITablelandRigPilots)7964": {
+            "label": "contract ITablelandRigPilots",
+            "numberOfBytes": "20"
+          },
+          "t_enum(MintPhase)7987": {
+            "label": "enum ITablelandRigs.MintPhase",
+            "members": [
+              "CLOSED",
+              "ALLOWLIST",
+              "WAITLIST",
+              "PUBLIC"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)1157_storage)": {
+            "label": "mapping(uint256 => struct ERC2981Upgradeable.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoyaltyInfo)1157_storage": {
+            "label": "struct ERC2981Upgradeable.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyFraction",
+                "type": "t_uint96",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
     }
   }
 }

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -13,6 +13,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "./utils/URITemplate.sol";
 import "./ITablelandRigs.sol";
 import "./ITablelandRigPilots.sol";
+import "./interfaces/IERC4906.sol";
 
 /**
  * @dev Implementation of {ITablelandRigs}.
@@ -22,6 +23,7 @@ contract TablelandRigs is
     URITemplate,
     ERC721AUpgradeable,
     ERC721AQueryableUpgradeable,
+    IERC4906,
     OwnableUpgradeable,
     PausableUpgradeable,
     ReentrancyGuardUpgradeable,
@@ -391,6 +393,7 @@ contract TablelandRigs is
             revert ITablelandRigPilots.Unauthorized();
 
         _pilots.trainRig(_msgSenderERC721A(), tokenId);
+        emit MetadataUpdate(tokenId);
     }
 
     /**
@@ -423,6 +426,7 @@ contract TablelandRigs is
             revert ITablelandRigPilots.Unauthorized();
 
         _pilots.pilotRig(_msgSenderERC721A(), tokenId, pilotAddr, pilotId);
+        emit MetadataUpdate(tokenId);
     }
 
     /**
@@ -466,6 +470,7 @@ contract TablelandRigs is
             revert ITablelandRigPilots.Unauthorized();
         // Pass `false` to indicate a standard (non-force) park
         _pilots.parkRig(tokenId, false);
+        emit MetadataUpdate(tokenId);
     }
 
     /**
@@ -498,6 +503,7 @@ contract TablelandRigs is
             if (!_exists(tokenIds[i])) revert OwnerQueryForNonexistentToken();
             // Pass `true` to indicate a force park
             _pilots.parkRig(tokenIds[i], true);
+            emit MetadataUpdate(tokenIds[i]);
         }
     }
 
@@ -586,7 +592,8 @@ contract TablelandRigs is
     {
         return
             ERC721AUpgradeable.supportsInterface(interfaceId) ||
-            ERC2981Upgradeable.supportsInterface(interfaceId);
+            ERC2981Upgradeable.supportsInterface(interfaceId) ||
+            interfaceId == bytes4(0x49064906); // See EIP-4096
     }
 
     // =============================

--- a/ethereum/contracts/interfaces/IERC4906.sol
+++ b/ethereum/contracts/interfaces/IERC4906.sol
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.10 <0.9.0;
 
-import "@openzeppelin/contracts/interfaces/IERC165.sol";
-import "@openzeppelin/contracts/interfaces/IERC721.sol";
-
 /**
  * @dev Interface for IERC4906 (EIP-721 Metadata Update Extension).
  */

--- a/ethereum/contracts/interfaces/IERC4906.sol
+++ b/ethereum/contracts/interfaces/IERC4906.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+import "@openzeppelin/contracts/interfaces/IERC165.sol";
+import "@openzeppelin/contracts/interfaces/IERC721.sol";
+
+/**
+ * @dev Interface for IERC4906 (EIP-721 Metadata Update Extension).
+ */
+interface IERC4906 {
+    /**
+     * @dev This event emits when the metadata of a token is changed.
+     * So that the third-party platforms such as NFT market could
+     * timely update the images and related attributes of the NFT.
+     */
+    event MetadataUpdate(uint256 _tokenId);
+
+    /**
+     * @dev This event emits when the metadata of a range of tokens is changed.
+     * So that the third-party platforms such as NFT market could
+     * timely update the images and related attributes of the NFTs.
+     */
+    event BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId);
+}

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/rigs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/rigs",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Unlicense",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",
@@ -3215,6 +3215,21 @@
       "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==",
       "dev": true
     },
+    "node_modules/bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -3258,9 +3273,10 @@
       "dev": true
     },
     "node_modules/bytes": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3939,11 +3955,12 @@
       }
     },
     "node_modules/depd": {
-      "version": "1.1.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/detect-port": {
@@ -5906,13 +5923,14 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6576,18 +6594,19 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-response-object": {
@@ -8428,9 +8447,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.1",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -8469,12 +8489,13 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.4.2",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       },
@@ -10139,11 +10160,12 @@
       }
     },
     "node_modules/statuses": {
-      "version": "1.5.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/stealthy-require": {
@@ -10881,6 +10903,21 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/utf8": {
       "version": "3.0.0",
       "dev": true,
@@ -10918,11 +10955,12 @@
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.6.1",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.8.2.tgz",
+      "integrity": "sha512-v7j6xhfLQfY7xQDrUP0BKbaNrmZ2/+egbqP9q3KYmOiPpnvAfol+32slgL0WX/5n8VPvKCK5EZ1HGrAVICSToA==",
       "dev": true,
-      "license": "LGPL-3.0",
       "dependencies": {
-        "bn.js": "^4.11.9",
+        "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
         "ethereumjs-util": "^7.1.0",
         "ethjs-unit": "0.1.6",
@@ -10933,6 +10971,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/web3-utils/node_modules/bn.js": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+      "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -13375,6 +13419,17 @@
       "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==",
       "dev": true
     },
+    "bufferutil": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.7.tgz",
+      "integrity": "sha512-kukuqc39WOHtdxtw4UScxF/WVnMFVSQVKhtx3AjZJzhd0RGZZldcrfSEbVsWWe6KNH253574cq5F+wpv0G9pJw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "builtins": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
@@ -13411,7 +13466,9 @@
       }
     },
     "bytes": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true
     },
     "call-bind": {
@@ -13886,7 +13943,9 @@
       "dev": true
     },
     "depd": {
-      "version": "1.1.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true
     },
     "detect-port": {
@@ -15226,12 +15285,14 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-port": {
@@ -15682,13 +15743,15 @@
       }
     },
     "http-errors": {
-      "version": "1.8.1",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       }
     },
@@ -16905,7 +16968,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.1",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
@@ -16923,11 +16988,13 @@
       }
     },
     "raw-body": {
-      "version": "2.4.2",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
       "dev": true,
       "requires": {
-        "bytes": "3.1.1",
-        "http-errors": "1.8.1",
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
       }
@@ -18080,7 +18147,9 @@
       }
     },
     "statuses": {
-      "version": "1.5.0",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
     "stealthy-require": {
@@ -18570,6 +18639,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "node-gyp-build": "^4.3.0"
+      }
+    },
     "utf8": {
       "version": "3.0.0",
       "dev": true
@@ -18596,16 +18676,26 @@
       }
     },
     "web3-utils": {
-      "version": "1.6.1",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.8.2.tgz",
+      "integrity": "sha512-v7j6xhfLQfY7xQDrUP0BKbaNrmZ2/+egbqP9q3KYmOiPpnvAfol+32slgL0WX/5n8VPvKCK5EZ1HGrAVICSToA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.11.9",
+        "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
         "ethereumjs-util": "^7.1.0",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
         "utf8": "3.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+          "dev": true
+        }
       }
     },
     "webidl-conversions": {

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -654,6 +654,8 @@ describe("Rigs", function () {
       expect(await rigs.supportsInterface("0x5b5e139f")).to.equal(true);
       // ERC165 interface ID for ERC2981
       expect(await rigs.supportsInterface("0x2a55205a")).to.equal(true);
+      // ERC165 interface ID for ERC4906
+      expect(await rigs.supportsInterface("0x49064906")).to.equal(true);
     });
   });
 
@@ -1942,6 +1944,61 @@ describe("Rigs", function () {
             receiver.address,
             BigNumber.from(tokenId)
           );
+      });
+    });
+
+    describe("metadata refresh", function () {
+      it("Should emit a metadata refresh event upon pilot status changes", async function () {
+        // First, mint a Rig to `tokenOwner`
+        await rigs.setMintPhase(3);
+        const tokenOwner = accounts[4];
+        let tx = await rigs
+          .connect(tokenOwner)
+          ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+        let receipt = await tx.wait();
+        let [event] = receipt.events ?? [];
+        const tokenId = event.args?.tokenId;
+        // Train the Rig & check `MetadataUpdate` was emitted
+        await expect(
+          rigs
+            .connect(tokenOwner)
+            ["trainRig(uint256)"](BigNumber.from(BigNumber.from(tokenId)))
+        )
+          .to.emit(rigs, "MetadataUpdate")
+          .withArgs(BigNumber.from(tokenId));
+        // Advance 172800 blocks (30 days)
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(172800),
+        ]);
+        // Park the Rig & check `MetadataUpdate` was emitted
+        await expect(
+          await rigs
+            .connect(tokenOwner)
+            ["parkRig(uint256)"](BigNumber.from(tokenId))
+        )
+          .to.emit(rigs, "MetadataUpdate")
+          .withArgs(BigNumber.from(tokenId));
+        // Deploy a faux ERC-721 token
+        const FauxERC721Factory = await ethers.getContractFactory(
+          "TestERC721Enumerable"
+        );
+        const fauxERC721 = await (await FauxERC721Factory.deploy()).deployed();
+        tx = await fauxERC721.connect(tokenOwner).mint();
+        receipt = await tx.wait();
+        [event] = receipt.events ?? [];
+        const pilotTokenId = event.args?.tokenId;
+        // Pilot the Rig & check `MetadataUpdate` was emitted
+        await expect(
+          await rigs
+            .connect(tokenOwner)
+            ["pilotRig(uint256,address,uint256)"](
+              BigNumber.from(tokenId),
+              fauxERC721.address,
+              pilotTokenId
+            )
+        )
+          .to.emit(rigs, "MetadataUpdate")
+          .withArgs(BigNumber.from(tokenId));
       });
     });
   });

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -1999,6 +1999,10 @@ describe("Rigs", function () {
         )
           .to.emit(rigs, "MetadataUpdate")
           .withArgs(BigNumber.from(tokenId));
+        // Park the Rig as contract owner & check `MetadataUpdate` was emitted
+        await expect(await rigs.parkRigAsOwner([BigNumber.from(tokenId)]))
+          .to.emit(rigs, "MetadataUpdate")
+          .withArgs(BigNumber.from(tokenId));
       });
     });
   });


### PR DESCRIPTION
- Emits a `MetadataUpdate` event with a `trainRig`, `parkRig`, `pilotRig`, or `parkRigAsOwner` action. This occurs on the `TablelandRigs` contract and not the `TablelandRigPilots`.
- Adds an additional check in `supportsInterface` with the IERC4906 inteface (0x49064906).
- Adds an additional contract in the `interface` directory for the `IERC4906.sol` metadata update.
- Includes a test for metadata update events.
- See the EIP for more details: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-4906.md
- Closes https://github.com/tablelandnetwork/rigs/issues/527