### PR TITLE
Fix training state mistmatch

### DIFF
--- a/ethereum/.openzeppelin/polygon-mumbai.json
+++ b/ethereum/.openzeppelin/polygon-mumbai.json
@@ -6240,6 +6240,448 @@
           }
         }
       }
+    },
+    "781c13150fabc8c5387bf64482dc07bbbfc72e30832e7140cd984cd2a134ff5b": {
+      "address": "0x3989fBf8311ff6B9895ed397981DEF0055232b04",
+      "txHash": "0x56386b64fbe39f212cb14113a9202d94d0d1ee686104e080a197650876a9b8ee",
+      "layout": {
+        "storage": [
+          {
+            "label": "_uriParts",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_string_storage)dyn_storage",
+            "contract": "URITemplate",
+            "src": "contracts/utils/URITemplate.sol:13"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "1",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_defaultRoyaltyInfo",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(RoyaltyInfo)1157_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:36"
+          },
+          {
+            "label": "_tokenRoyaltyInfo",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)1157_storage)",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:123"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "352",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "maxSupply",
+            "offset": 0,
+            "slot": "402",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:34"
+          },
+          {
+            "label": "mintPrice",
+            "offset": 0,
+            "slot": "403",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:37"
+          },
+          {
+            "label": "beneficiary",
+            "offset": 0,
+            "slot": "404",
+            "type": "t_address_payable",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:40"
+          },
+          {
+            "label": "allowlistRoot",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:43"
+          },
+          {
+            "label": "waitlistRoot",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:46"
+          },
+          {
+            "label": "mintPhase",
+            "offset": 0,
+            "slot": "407",
+            "type": "t_enum(MintPhase)7995",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:49"
+          },
+          {
+            "label": "_contractInfoURI",
+            "offset": 0,
+            "slot": "408",
+            "type": "t_string_storage",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:52"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "409",
+            "type": "t_contract(ITablelandRigPilots)7972",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:55"
+          },
+          {
+            "label": "_allowTransferWhileFlying",
+            "offset": 20,
+            "slot": "409",
+            "type": "t_bool",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:58"
+          },
+          {
+            "label": "_admin",
+            "offset": 0,
+            "slot": "410",
+            "type": "t_address",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:61"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_address_payable": {
+            "label": "address payable",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_string_storage)dyn_storage": {
+            "label": "string[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ITablelandRigPilots)7972": {
+            "label": "contract ITablelandRigPilots",
+            "numberOfBytes": "20"
+          },
+          "t_enum(MintPhase)7995": {
+            "label": "enum ITablelandRigs.MintPhase",
+            "members": [
+              "CLOSED",
+              "ALLOWLIST",
+              "WAITLIST",
+              "PUBLIC"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)1157_storage)": {
+            "label": "mapping(uint256 => struct ERC2981Upgradeable.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoyaltyInfo)1157_storage": {
+            "label": "struct ERC2981Upgradeable.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyFraction",
+                "type": "t_uint96",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "279c0e69f766144ca1451923d22307a4c9633f0e2a99198efdf3685e9e0255fb": {
+      "address": "0x8e8bD49c31E7d1E76BAf4E8B104003Afa58D1c75",
+      "txHash": "0x0992cf0693f16b4b5394ed56a54bd473ae7261e1df09ab98b7033e00f821661c",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:211"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "_parent",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:45"
+          },
+          {
+            "label": "_pilotSessionsTableId",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_uint256",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:48"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_mapping(t_uint16,t_uint256)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:56"
+          },
+          {
+            "label": "_pilotIndex",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_mapping(t_uint192,t_uint16)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:60"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint16,t_uint256)": {
+            "label": "mapping(uint16 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint192,t_uint16)": {
+            "label": "mapping(uint192 => uint16)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint192": {
+            "label": "uint192",
+            "numberOfBytes": "24"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/ethereum/contracts/ITablelandRigPilots.sol
+++ b/ethereum/contracts/ITablelandRigPilots.sol
@@ -99,6 +99,20 @@ interface ITablelandRigPilots {
     function trainRig(address sender, uint256 tokenId) external;
 
     /**
+     * @dev Puts a single Rig in flight with a "stock" trainer pilot.
+     *
+     * sender - the initiator address
+     * tokenId - the unique Rig token identifier
+     *
+     * Requirements:
+     *
+     * - `tokenId` must exist
+     * - `sender` must own the Rig
+     * - Must already be trained & currently parked
+     */
+    function pilotRig(address sender, uint256 tokenId) external;
+
+    /**
      * @dev Puts a single Rig in flight by setting a custom `Pilot`.
      *
      * sender - the initiator address
@@ -110,7 +124,7 @@ interface ITablelandRigPilots {
      *
      * - `tokenId` must exist
      * - `sender` must own the Rig
-     * - ability to pilot must be `true` (trained & flying with trainer, or already trained & parked)
+     * - Ability to pilot must be `true` (trained & flying with trainer, or already trained & parked)
      * - `pilotContract` must be an ERC-721 contract; cannot be the Rigs contract
      * - `pilotId` must be owned by `msg.sender` at `pilotContract`
      * - `Pilot` can only be associated with one Rig at a time; parks the other Rig on conflict

--- a/ethereum/contracts/ITablelandRigs.sol
+++ b/ethereum/contracts/ITablelandRigs.sol
@@ -236,6 +236,7 @@ interface ITablelandRigs {
      * Requirements:
      *
      * - Input array of `tokenIds` must be non-empty
+     * - `msg.sender` must own the Rig
      * - There cannot exist a duplicate value in `tokenIds`
      * - Values are processed in order
      * - See `trainRig` for additional constraints on a per-token basis
@@ -252,10 +253,11 @@ interface ITablelandRigs {
      * Requirements:
      *
      * - `tokenId` must exist
-     * - ability to pilot must be `true` (trained & flying with trainer, or already trained & parked)
-     * - `pilotContract` must be an ERC-721 contract; cannot be the Rigs contract
-     * - `pilotId` must be owned by `msg.sender` at `pilotContract`
-     * - pilot can only be associated with one Rig at a time; parks the other Rig on conflict
+     * - `msg.sender` must own the Rig
+     * - Must be trained & flying with trainer, or already trained & parked
+     * - `pilotContract` must be an ERC-721 contract *or* 0x0 to indicate a trainer pilot; cannot be the Rigs contract
+     * - `pilotId` must be owned by `msg.sender` at `pilotContract` (does not apply to trainer pilots)
+     * - Pilot can only be associated with one Rig at a time; parks the other Rig on conflict (does not apply to trainer pilots)
      */
     function pilotRig(
         uint256 tokenId,
@@ -274,7 +276,8 @@ interface ITablelandRigs {
      *
      * - All input parameters must be non-empty
      * - All input parameters must have an equal length
-     * - There cannot exist a duplicate value in each of the individual parameters
+     * - There cannot exist a duplicate value in each of the individual parameters,
+     *   except if using a trainer pilot (i.e., trainers aren't unique/owned NFTs).
      * - Values are processed in order (i.e., use same index for each array)
      * - See `pilotRig` for additional constraints on a per-token basis
      */

--- a/ethereum/contracts/ITablelandRigs.sol
+++ b/ethereum/contracts/ITablelandRigs.sol
@@ -204,6 +204,19 @@ interface ITablelandRigs {
     ) external view returns (ITablelandRigPilots.PilotInfo memory);
 
     /**
+     * @dev Retrieves pilot info for multiple Rigs.
+     *
+     * tokenIds - the unique Rig token identifiers
+     *
+     * Requirements:
+     *
+     * - `tokenIds` must exist
+     */
+    function pilotInfo(
+        uint256[] calldata tokenIds
+    ) external view returns (ITablelandRigPilots.PilotInfo[] memory);
+
+    /**
      * @dev Trains a single Rig for a period of 30 days, putting it in-flight.
      *
      * tokenId - the unique Rig token identifier

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -282,6 +282,50 @@ contract TablelandRigPilots is
     /**
      * @dev See {ITablelandRigPilots-pilotRig}.
      */
+    function pilotRig(address sender, uint256 tokenId) external onlyParent {
+        // Validate the Rig can be piloted with a trainer pilot. Note that
+        // `_canPilot` allows for in-flight piloting once trained *and* in
+        // `TRAINING` status, but this only allows for piloting a with trainer
+        // if `PARKED`.
+        if (_pilotStatus(tokenId) != GarageStatus.PARKED)
+            revert InvalidPilotStatus();
+
+        // Assign a trainer pilot to the Rig in `_pilots`. The pilot contract is
+        // `0` and pilot ID `2`—this is needed to differentiate from a
+        // `TRAINING` Rig's pilot, which has a pilot ID of `1`.
+        _setPilotData(uint16(tokenId), 0, 2);
+
+        // Set the start time for the new pilot session
+        _setStartTime(uint16(tokenId), uint64(block.number));
+
+        // Insert the trainer pilot into the Tableland pilot sessions table
+        TablelandDeployments.get().runSQL(
+            address(this),
+            _pilotSessionsTableId,
+            SQLHelpers.toInsert(
+                _PILOT_SESSIONS_PREFIX,
+                _pilotSessionsTableId,
+                "rig_id,owner,pilot_contract,pilot_id,start_time",
+                string.concat(
+                    StringsUpgradeable.toString(uint16(tokenId)),
+                    ",",
+                    SQLHelpers.quote(StringsUpgradeable.toHexString(sender)),
+                    ",",
+                    SQLHelpers.quote(Strings.toHexString(address(0))),
+                    ",",
+                    StringsUpgradeable.toString(uint32(2)),
+                    ",",
+                    StringsUpgradeable.toString(uint64(block.number))
+                )
+            )
+        );
+
+        emit Piloted(tokenId, address(0), 2);
+    }
+
+    /**
+     * @dev See {ITablelandRigPilots-pilotRig}.
+     */
     function pilotRig(
         address sender,
         uint256 tokenId,
@@ -305,7 +349,8 @@ contract TablelandRigPilots is
         // Validate the Rig can be piloted
         if (!_canPilot(tokenId)) revert InvalidPilotStatus();
 
-        // Initialize the packed "pilot data" (pilot ID `uint32` with a pilot contract `uint160`, shifted 32 bits)
+        // Initialize the packed "pilot data" (pilot ID `uint32` with a pilot
+        // contract `uint160`, shifted 32 bits)
         uint192 pilotData = (uint192(pilotId) |
             (uint192(uint160(pilotAddr)) << 32));
 
@@ -320,8 +365,9 @@ contract TablelandRigPilots is
             _pilotStatus(_pilotIndex[pilotData]) != GarageStatus.PARKED
         ) parkRig(_pilotIndex[pilotData], false);
 
-        // If the Rig is training, end its training session (no parking required) to then open a new pilot session
-        // Pilot has completed training at this point (training validation is checked above)
+        // If the Rig is training, end its training session (no parking
+        // required) to then open a new pilot session. Pilot has completed
+        // training at this point (training validation is checked above)
         if (_pilotStatus(tokenId) == GarageStatus.TRAINING) {
             // Update the pilot's existing training session with its `end_time`
             string memory setters = string.concat(

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -298,22 +298,18 @@ contract TablelandRigPilots is
         // Set the start time for the new pilot session
         _setStartTime(uint16(tokenId), uint64(block.number));
 
-        // Insert the trainer pilot into the Tableland pilot sessions table
+        // Insert the trainer pilot session into the Tableland pilot sessions table
         TablelandDeployments.get().runSQL(
             address(this),
             _pilotSessionsTableId,
             SQLHelpers.toInsert(
                 _PILOT_SESSIONS_PREFIX,
                 _pilotSessionsTableId,
-                "rig_id,owner,pilot_contract,pilot_id,start_time",
+                "rig_id,owner,start_time",
                 string.concat(
                     StringsUpgradeable.toString(uint16(tokenId)),
                     ",",
                     SQLHelpers.quote(StringsUpgradeable.toHexString(sender)),
-                    ",",
-                    SQLHelpers.quote(Strings.toHexString(address(0))),
-                    ",",
-                    StringsUpgradeable.toString(uint32(2)),
                     ",",
                     StringsUpgradeable.toString(uint64(block.number))
                 )

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -395,10 +395,13 @@ contract TablelandRigPilots is
         uint64 startTime = pilotStartTime(tokenId);
         bool trainingIncomplete = status == GarageStatus.TRAINING &&
             !(block.number >= startTime + _PILOT_TRAINING_DURATION);
+        bool forceParkedWhileTraining = status == GarageStatus.TRAINING &&
+            force;
+        // Pilot training is incomplete; reset the training pilot such that the Rig must train again
+        if (trainingIncomplete || forceParkedWhileTraining)
+            _setPilotData(uint16(tokenId), 0, 0);
         // If the pilot is untrained or being force parked, there are zero flight time rewards
         if (trainingIncomplete || force) {
-            // Reset the training pilot such that the Rig must train again
-            _setPilotData(uint16(tokenId), 0, 0);
             // Update the row in pilot sessions table with its `end_time` equal to the `start_time`
             setters = string.concat(
                 "end_time=",

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -395,10 +395,10 @@ contract TablelandRigPilots is
         uint64 startTime = pilotStartTime(tokenId);
         bool trainingIncomplete = status == GarageStatus.TRAINING &&
             !(block.number >= startTime + _PILOT_TRAINING_DURATION);
-        // Pilot training is incomplete; reset the training pilot such that the Rig must train again
-        if (trainingIncomplete) _setPilotData(uint16(tokenId), 0, 0);
         // If the pilot is untrained or being force parked, there are zero flight time rewards
         if (trainingIncomplete || force) {
+            // Reset the training pilot such that the Rig must train again
+            _setPilotData(uint16(tokenId), 0, 0);
             // Update the row in pilot sessions table with its `end_time` equal to the `start_time`
             setters = string.concat(
                 "end_time=",

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -412,15 +412,32 @@ contract TablelandRigs is
     }
 
     /**
-     * @dev See {ITablelandRigs-pilotInfo}.
+     * @dev See {ITablelandRigs-pilotInfo(uint256)}.
      */
     function pilotInfo(
         uint256 tokenId
-    ) external view returns (ITablelandRigPilots.PilotInfo memory) {
+    ) public view returns (ITablelandRigPilots.PilotInfo memory) {
         // Check the Rig `tokenId` exists
         if (!_exists(tokenId)) revert OwnerQueryForNonexistentToken();
 
         return _pilots.pilotInfo(tokenId);
+    }
+
+    /**
+     * @dev See {ITablelandRigPilots-pilotInfo(uint256[])}.
+     */
+    function pilotInfo(
+        uint256[] calldata tokenIds
+    ) external view returns (ITablelandRigPilots.PilotInfo[] memory) {
+        // For each token, call `pilotInfo`
+        ITablelandRigPilots.PilotInfo[]
+            memory allPilotInfo = new ITablelandRigPilots.PilotInfo[](
+                tokenIds.length
+            );
+        for (uint8 i = 0; i < tokenIds.length; i++) {
+            allPilotInfo[i] = pilotInfo(tokenIds[i]);
+        }
+        return allPilotInfo;
     }
 
     /**

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -483,7 +483,17 @@ contract TablelandRigs is
         if (ownerOf(tokenId) != _msgSenderERC721A())
             revert ITablelandRigPilots.Unauthorized();
 
-        _pilots.pilotRig(_msgSenderERC721A(), tokenId, pilotAddr, pilotId);
+        // If the supplied pilot address is `0x0`, then assume a trainer pilot
+        // (note: `pilotId` has no impact here). Otherwise, proceed with a
+        // custom pilot. The overloaded methods direct changes accordingly.
+        pilotAddr == address(0)
+            ? _pilots.pilotRig(_msgSenderERC721A(), tokenId)
+            : _pilots.pilotRig(
+                _msgSenderERC721A(),
+                tokenId,
+                pilotAddr,
+                pilotId
+            );
         emit MetadataUpdate(tokenId);
     }
 

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -412,7 +412,7 @@ contract TablelandRigs is
     }
 
     /**
-     * @dev See {ITablelandRigs-pilotInfo(uint256)}.
+     * @dev See {ITablelandRigs-pilotInfo}.
      */
     function pilotInfo(
         uint256 tokenId
@@ -424,7 +424,7 @@ contract TablelandRigs is
     }
 
     /**
-     * @dev See {ITablelandRigPilots-pilotInfo(uint256[])}.
+     * @dev See {ITablelandRigs-pilotInfo}.
      */
     function pilotInfo(
         uint256[] calldata tokenIds

--- a/ethereum/deployments.ts
+++ b/ethereum/deployments.ts
@@ -10,7 +10,7 @@ export interface RigsDeployment {
   tablelandChain: helpers.ChainName;
   tablelandHost:
     | "https://tableland.network"
-    | "https://testnet.tableland.network"
+    | "https://testnets.tableland.network"
     | "https://staging.tableland.network"
     | "http://localhost:8080";
 
@@ -52,7 +52,7 @@ export const deployments: RigsDeployments = {
     royaltyContractAddress: "0xb61974afD4348DA16e45BC48d53883A281bc4A6e",
     pilotsAddress: "0x864655946432f52AE16BDE9af054380b3dE06789",
     tablelandChain: "maticmum",
-    tablelandHost: "https://testnet.tableland.network",
+    tablelandHost: "https://testnets.tableland.network",
     contractTable: "rigs_contract_80001_3819",
     allowlistTable: "rigs_allowlist_80001_3820",
     partsTable: "parts_80001_4038",

--- a/ethereum/test/TablelandRigPilots.ts
+++ b/ethereum/test/TablelandRigPilots.ts
@@ -88,7 +88,14 @@ describe("Pilots", function () {
       const _pilots = pilots.connect(accounts[2]);
 
       await expect(
-        _pilots.pilotRig(
+        _pilots["pilotRig(address,uint256)"](
+          ethers.constants.AddressZero,
+          BigNumber.from(1)
+        )
+      ).to.be.rejectedWith("Pilots: caller is not the parent");
+
+      await expect(
+        _pilots["pilotRig(address,uint256,address,uint256)"](
           ethers.constants.AddressZero,
           BigNumber.from(1),
           ethers.constants.AddressZero,

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -2255,14 +2255,16 @@ describe("Rigs", function () {
         const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Check pilot is untrained
-        let pilotInfo = await rigs.pilotInfo(BigNumber.from(tokenId));
+        let pilotInfo = await rigs["pilotInfo(uint256)"](
+          BigNumber.from(tokenId)
+        );
         expect(pilotInfo.status).to.equal(0);
         // Start training
         await rigs
           .connect(tokenOwner)
           ["trainRig(uint256)"](BigNumber.from(tokenId));
         // Check pilot is training
-        pilotInfo = await rigs.pilotInfo(BigNumber.from(tokenId));
+        pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(1);
 
         // Set admin
@@ -2276,7 +2278,7 @@ describe("Rigs", function () {
           .to.emit(pilots, "Parked")
           .withArgs(BigNumber.from(tokenId));
         // Check pilot is back to untrained
-        pilotInfo = await rigs.pilotInfo(BigNumber.from(tokenId));
+        pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(0);
       });
 

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -2107,7 +2107,7 @@ describe("Rigs", function () {
         const pilotInfo = await rigs["pilotInfo(uint256)"](
           BigNumber.from(tokenId)
         );
-        // Check that the pilot is now `0` since training was incomplete
+        // Check that the pilot is now `0` since it was force parked while training
         expect(pilotInfo.status).to.equal(0);
         expect(pilotInfo.pilotable).to.equal(false);
         expect(pilotInfo.started).to.equal(BigNumber.from(0));

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -1303,8 +1303,8 @@ describe("Rigs", function () {
         let tx = await rigs
           .connect(tokenOwner)
           ["mint(uint256)"](1, { value: getCost(1, 0.05) });
-        let receipt = await tx.wait();
-        let [event] = receipt.events ?? [];
+        const receipt = await tx.wait();
+        const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Start to train the Rig
         tx = await rigs
@@ -1330,11 +1330,11 @@ describe("Rigs", function () {
         // First, mint a Rig to `rigTokenOwner`
         await rigs.setMintPhase(3);
         const rigTokenOwner = accounts[4];
-        let tx = await rigs
+        const tx = await rigs
           .connect(rigTokenOwner)
           ["mint(uint256)"](1, { value: getCost(1, 0.05) });
-        let receipt = await tx.wait();
-        let [event] = receipt.events ?? [];
+        const receipt = await tx.wait();
+        const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs


### PR DESCRIPTION
This PR fixes an issue where contract and table state diverged due to logic in `parkRig`. It also adds an overloaded `pilotInfo` that can be called with multiple Rig IDs.

The original issue boils down to the following in `parkRig` where an initial `trainingIncomplete` check would `_setPilotData`, separate from the ensuing `UPDATE` statement. 
```solidity
// Pilot training is incomplete; reset the training pilot such that the Rig must train again
if (trainingIncomplete) _setPilotData(uint16(tokenId), 0, 0);
// If the pilot is untrained or being force parked, there are zero flight time rewards
if (trainingIncomplete || force) {
    // Update the row in pilot sessions table with its `end_time` equal to the `start_time`
    setters = string.concat(
        "end_time=",
        StringsUpgradeable.toString(startTime)
    );
} else {
  // ...
}
```
The contract and table state are now synced:
```solidity
if (trainingIncomplete || force) {
    _setPilotData(uint16(tokenId), 0, 0);
    setters = string.concat(
        "end_time=",
        StringsUpgradeable.toString(startTime)
    );
}
```
The one callout is that a force parked Rig will revert to a training status and have to go through training again, even it was previously able to pilot the Rig. Lore-wise with these changes, a Rig is sentient in that it can be trained to handle a pilot, but if the pilot acts maliciously (i.e., tries to sell the Rig while in flight), the Rig loses training knowledge and must re-train.