### PR TITLE
Add delegate.cash support

### DIFF
--- a/ethereum/contracts/DelegateCashMock.sol
+++ b/ethereum/contracts/DelegateCashMock.sol
@@ -1,23 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.8.10 <0.9.0;
 
-interface MockDelegateCashInterface {
-    function checkDelegateForToken(
-        address delegate,
-        address vault,
-        address contract_,
-        uint256 tokenId
-    ) external view returns (bool);
+import "./interfaces/IDelegationRegistry.sol";
 
-    function registerDelegate(
-        address delegate,
-        address vault,
-        address contract_,
-        uint256 tokenId
-    ) external;
-}
-
-contract DelegateCashMock is MockDelegateCashInterface {
+contract DelegateCashMock is IDelegationRegistry {
     mapping(address => mapping(address => mapping(uint256 => mapping(address => bool)))) delegations;
 
     function checkDelegateForToken(

--- a/ethereum/contracts/DelegateCashMock.sol
+++ b/ethereum/contracts/DelegateCashMock.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+interface MockDelegateCashInterface {
+    function checkDelegateForToken(
+        address delegate,
+        address vault,
+        address contract_,
+        uint256 tokenId
+    ) external view returns (bool);
+
+    function registerDelegate(
+        address delegate,
+        address vault,
+        address contract_,
+        uint256 tokenId
+    ) external;
+}
+
+contract DelegateCashMock is MockDelegateCashInterface {
+    mapping(address => mapping(address => mapping(uint256 => mapping(address => bool)))) delegations;
+
+    function checkDelegateForToken(
+        address delegate,
+        address vault,
+        address contract_,
+        uint256 tokenId
+    ) external view returns (bool) {
+        return delegations[vault][contract_][tokenId][delegate];
+    }
+
+    function registerDelegate(
+        address delegate,
+        address vault,
+        address contract_,
+        uint256 tokenId
+    ) external {
+        delegations[vault][contract_][tokenId][delegate] = true;
+    }
+}

--- a/ethereum/contracts/ITablelandRigs.sol
+++ b/ethereum/contracts/ITablelandRigs.sol
@@ -175,17 +175,6 @@ interface ITablelandRigs {
     function setAdmin(address admin) external;
 
     /**
-     * @dev Initializes the delegateCash address;
-     *
-     * delegateCashAddress - `DelegateCashInterface` contract address
-     *
-     * Requirements:
-     *
-     * - `msg.sender` must be contract owner
-     */
-    function initDelegateCash(address delegateCashAddress) external;
-
-    /**
      * @dev Initializes Rig pilots by creating the pilot sessions table.
      *
      * pilotsAddress - `ITablelandRigPilots` contract address

--- a/ethereum/contracts/ITablelandRigs.sol
+++ b/ethereum/contracts/ITablelandRigs.sol
@@ -175,6 +175,17 @@ interface ITablelandRigs {
     function setAdmin(address admin) external;
 
     /**
+     * @dev Initializes the delegateCash address;
+     *
+     * delegateCashAddress - `DelegateCashInterface` contract address
+     *
+     * Requirements:
+     *
+     * - `msg.sender` must be contract owner
+     */
+    function initDelegateCash(address delegateCashAddress) external;
+
+    /**
      * @dev Initializes Rig pilots by creating the pilot sessions table.
      *
      * pilotsAddress - `ITablelandRigPilots` contract address

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -534,12 +534,7 @@ contract TablelandRigs is
         // custom pilot. The overloaded methods direct changes accordingly.
         pilotAddr == address(0)
             ? _pilots.pilotRig(_msgSenderERC721A(), tokenId)
-            : _pilots.pilotRig(
-                sender,
-                tokenId,
-                pilotAddr,
-                pilotId
-            );
+            : _pilots.pilotRig(sender, tokenId, pilotAddr, pilotId);
 
         emit MetadataUpdate(tokenId);
     }

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -62,7 +62,8 @@ contract TablelandRigs is
     address private _admin;
 
     // Delegate.cash registry address
-    IDelegationRegistry private _delegateCash;
+    IDelegationRegistry private constant _delegateCash =
+        IDelegationRegistry(0x00000000000076A84feF008CDAbe6409d2FE638B);
 
     function initialize(
         uint256 _maxSupply,
@@ -371,13 +372,6 @@ contract TablelandRigs is
      */
     function unpause() external onlyOwner {
         _unpause();
-    }
-
-    /**
-     * @dev See {ITablelandRigs-initDelegateCash}.
-     */
-    function initDelegateCash(address delegateCashAddress) external onlyOwner {
-        _delegateCash = IDelegateCash(delegateCashAddress);
     }
 
     // =============================

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -533,7 +533,7 @@ contract TablelandRigs is
         // (note: `pilotId` has no impact here). Otherwise, proceed with a
         // custom pilot. The overloaded methods direct changes accordingly.
         pilotAddr == address(0)
-            ? _pilots.pilotRig(_msgSenderERC721A(), tokenId)
+            ? _pilots.pilotRig(sender, tokenId)
             : _pilots.pilotRig(sender, tokenId, pilotAddr, pilotId);
 
         emit MetadataUpdate(tokenId);

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -14,15 +14,7 @@ import "./utils/URITemplate.sol";
 import "./ITablelandRigs.sol";
 import "./ITablelandRigPilots.sol";
 import "./interfaces/IERC4906.sol";
-
-interface DelegateCashInterface {
-    function checkDelegateForToken(
-        address delegate,
-        address vault,
-        address contract_,
-        uint256 tokenId
-    ) external view returns (bool);
-}
+import "./interfaces/IDelegationRegistry.sol";
 
 /**
  * @dev Implementation of {ITablelandRigs}.
@@ -69,7 +61,7 @@ contract TablelandRigs is
     // Admin address
     address private _admin;
 
-    DelegateCashInterface private _delegateCash;
+    IDelegationRegistry private _delegateCash;
 
     function initialize(
         uint256 _maxSupply,
@@ -384,7 +376,7 @@ contract TablelandRigs is
      * @dev See {ITablelandRigs-initDelegateCash}.
      */
     function initDelegateCash(address delegateCashAddress) external onlyOwner {
-        _delegateCash = DelegateCashInterface(delegateCashAddress);
+        _delegateCash = IDelegateCash(delegateCashAddress);
     }
 
     // =============================

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -61,6 +61,7 @@ contract TablelandRigs is
     // Admin address
     address private _admin;
 
+    // Delegate.cash registry address
     IDelegationRegistry private _delegateCash;
 
     function initialize(

--- a/ethereum/contracts/interfaces/IDelegationRegistry.sol
+++ b/ethereum/contracts/interfaces/IDelegationRegistry.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+/**
+ * @dev A simplified version of the delegate.cash interface
+ */
+interface IDelegationRegistry {
+    /**
+     * @notice Returns true if the address is delegated to act on your behalf for a specific token, the token's contract or an entire vault
+     * @param delegate The hotwallet to act on your behalf
+     * @param contract_ The address for the contract you're delegating
+     * @param tokenId The token id for the token you're delegating
+     * @param vault The cold wallet who issued the delegation
+     */
+    function checkDelegateForToken(
+        address delegate,
+        address vault,
+        address contract_,
+        uint256 tokenId
+    ) external view returns (bool);
+}

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -12,6 +12,7 @@ import {
   PaymentSplitter,
   TablelandRigs,
   TablelandRigPilots,
+  MockDelegateCashInterface,
 } from "../typechain-types";
 
 chai.use(chaiAsPromised);
@@ -33,6 +34,7 @@ describe("Rigs", function () {
   let allowlistTree: MerkleTree;
   let waitlistTree: MerkleTree;
   let pilots: TablelandRigPilots;
+  let delegateCash: MockDelegateCashInterface;
 
   // Use a fixture, which runs *once* to help ensure deterministic contract addresses
   async function deployRigsFixture() {
@@ -122,7 +124,9 @@ describe("Rigs", function () {
     const DelegateCashFactory = await ethers.getContractFactory(
       "DelegateCashMock"
     );
-    const delegateCash = await (await DelegateCashFactory.deploy()).deployed();
+    delegateCash = await (
+      (await DelegateCashFactory.deploy()) as MockDelegateCashInterface
+    ).deployed();
 
     await (await rigs.initDelegateCash(delegateCash.address)).wait();
   }
@@ -2471,6 +2475,149 @@ describe("Rigs", function () {
         await expect(await rigs.parkRigAsOwner([BigNumber.from(tokenId)]))
           .to.emit(rigs, "MetadataUpdate")
           .withArgs(BigNumber.from(tokenId));
+      });
+    });
+
+    describe("delegation", function () {
+      describe("initDelegateCash", function () {
+        it("Should block contract non-owner", async function () {
+          const _rigs = rigs.connect(accounts[2]);
+
+          await expect(
+            _rigs.initDelegateCash(ethers.constants.AddressZero)
+          ).to.be.rejectedWith("Ownable: caller is not the owner");
+        });
+      });
+
+      describe("trainRig", function () {
+        it("Should train Rig if msg.sender is registered delegate for token.owner", async function () {
+          // First, mint a Rig to `tokenOwner`
+          await rigs.setMintPhase(3);
+          const tokenOwner = accounts[4];
+          const tx = await rigs
+            .connect(tokenOwner)
+            ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+          const receipt = await tx.wait();
+          const [event] = receipt.events ?? [];
+          const tokenId = event.args?.tokenId;
+
+          const delegate = accounts[5];
+          // Setup delegation
+          await delegateCash.registerDelegate(
+            delegate.address,
+            tokenOwner.address,
+            rigs.address,
+            tokenId
+          );
+
+          // Train the Rig
+          await expect(
+            rigs.connect(delegate)["trainRig(uint256)"](BigNumber.from(tokenId))
+          )
+            .to.emit(pilots, "Training")
+            .withArgs(BigNumber.from(tokenId));
+        });
+      });
+
+      describe("pilotRig", function () {
+        it("Should pilot rig if msg.sender is registered delegate for token.owner", async function () {
+          // First, mint a Rig to `rigTokenOwner`
+          await rigs.setMintPhase(3);
+          const rigTokenOwner = accounts[4];
+          let tx = await rigs
+            .connect(rigTokenOwner)
+            ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+          let receipt = await tx.wait();
+          let [event] = receipt.events ?? [];
+          const rigTokenId = event.args?.tokenId;
+          // Train the Rig, putting it in-flight, and advance 1 block
+          await rigs
+            .connect(rigTokenOwner)
+            ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+          // Advance 172800 blocks (30 days)
+          await network.provider.send("hardhat_mine", [
+            ethers.utils.hexValue(172800),
+          ]);
+          // Park the Rig now that training has been completed
+          await rigs
+            .connect(rigTokenOwner)
+            ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+          // Deploy a faux ERC-721 token but mint to an address *not* `rigTokenOwner`
+          const FauxERC721Factory = await ethers.getContractFactory(
+            "TestERC721Enumerable"
+          );
+          const fauxERC721 = await (
+            await FauxERC721Factory.deploy()
+          ).deployed();
+          // Mint a faux NFT and set the pilot to an ERC-721 contract & pilot
+          tx = await fauxERC721.connect(rigTokenOwner).mint();
+          receipt = await tx.wait();
+          [event] = receipt.events ?? [];
+          const pilotTokenIdRigOwner = event.args?.tokenId;
+
+          // Setup delegation
+          const delegate = accounts[5];
+          await delegateCash.registerDelegate(
+            delegate.address,
+            rigTokenOwner.address,
+            rigs.address,
+            rigTokenId
+          );
+
+          await expect(
+            await rigs
+              .connect(delegate)
+              ["pilotRig(uint256,address,uint256)"](
+                BigNumber.from(rigTokenId),
+                fauxERC721.address,
+                pilotTokenIdRigOwner
+              )
+          )
+            .to.emit(pilots, "Piloted")
+            .withArgs(
+              BigNumber.from(rigTokenId),
+              fauxERC721.address,
+              BigNumber.from(pilotTokenIdRigOwner)
+            );
+        });
+      });
+
+      describe("parkRig", function () {
+        it("Should park Rig if msg.sender is registered delegate for token.owner", async function () {
+          // First, mint a Rig to `tokenOwner`
+          await rigs.setMintPhase(3);
+          const tokenOwner = accounts[4];
+          const tx = await rigs
+            .connect(tokenOwner)
+            ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+          const receipt = await tx.wait();
+          const [event] = receipt.events ?? [];
+          const tokenId = event.args?.tokenId;
+
+          // Train the Rig
+          await expect(
+            rigs
+              .connect(tokenOwner)
+              ["trainRig(uint256)"](BigNumber.from(tokenId))
+          )
+            .to.emit(pilots, "Training")
+            .withArgs(BigNumber.from(tokenId));
+
+          // Setup delegation
+          const delegate = accounts[5];
+          await delegateCash.registerDelegate(
+            delegate.address,
+            tokenOwner.address,
+            rigs.address,
+            tokenId
+          );
+
+          await expect(
+            rigs.connect(delegate)["parkRig(uint256)"](BigNumber.from(tokenId))
+          )
+            .to.emit(pilots, "Parked")
+            .withArgs(BigNumber.from(tokenId));
+        });
       });
     });
   });

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -12,7 +12,7 @@ import {
   PaymentSplitter,
   TablelandRigs,
   TablelandRigPilots,
-  MockDelegateCashInterface,
+  DelegateCashMock,
 } from "../typechain-types";
 
 chai.use(chaiAsPromised);
@@ -34,7 +34,7 @@ describe("Rigs", function () {
   let allowlistTree: MerkleTree;
   let waitlistTree: MerkleTree;
   let pilots: TablelandRigPilots;
-  let delegateCash: MockDelegateCashInterface;
+  let delegateCash: DelegateCashMock;
 
   // Use a fixture, which runs *once* to help ensure deterministic contract addresses
   async function deployRigsFixture() {
@@ -125,7 +125,7 @@ describe("Rigs", function () {
       "DelegateCashMock"
     );
     delegateCash = await (
-      (await DelegateCashFactory.deploy()) as MockDelegateCashInterface
+      (await DelegateCashFactory.deploy()) as DelegateCashMock
     ).deployed();
 
     await (await rigs.initDelegateCash(delegateCash.address)).wait();

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -118,6 +118,13 @@ describe("Rigs", function () {
 
     // Set pilots on rigs
     await (await rigs.initPilots(pilots.address)).wait();
+
+    const DelegateCashFactory = await ethers.getContractFactory(
+      "DelegateCashMock"
+    );
+    const delegateCash = await (await DelegateCashFactory.deploy()).deployed();
+
+    await (await rigs.initDelegateCash(delegateCash.address)).wait();
   }
 
   beforeEach(async function () {

--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -17,6 +17,7 @@
         "@tableland/sdk": "^4.0.0-pre.8",
         "alchemy-sdk": "^2.2.5",
         "chakra-react-select": "^4.4.2",
+        "delegatecash": "^0.4.1",
         "ethers": "^5.7.2",
         "framer-motion": "^10.11.2",
         "lodash": "^4.17.21",
@@ -4948,6 +4949,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delegatecash": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/delegatecash/-/delegatecash-0.4.1.tgz",
+      "integrity": "sha512-udA3nGyCLnPacoekeeIdDO6o3aRzM9imGuaOilPOOExpCz8OLHKNtKlwHZg58Wjh6VfRPKD1EsQeI0ltCvKL2w==",
+      "dependencies": {
+        "ethers": "^5.7.1"
       }
     },
     "node_modules/depd": {
@@ -11233,6 +11242,14 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
       "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw=="
+    },
+    "delegatecash": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/delegatecash/-/delegatecash-0.4.1.tgz",
+      "integrity": "sha512-udA3nGyCLnPacoekeeIdDO6o3aRzM9imGuaOilPOOExpCz8OLHKNtKlwHZg58Wjh6VfRPKD1EsQeI0ltCvKL2w==",
+      "requires": {
+        "ethers": "^5.7.1"
+      }
     },
     "depd": {
       "version": "1.1.2",

--- a/garage/package.json
+++ b/garage/package.json
@@ -18,6 +18,7 @@
     "@tableland/sdk": "^4.0.0-pre.8",
     "alchemy-sdk": "^2.2.5",
     "chakra-react-select": "^4.4.2",
+    "delegatecash": "^0.4.1",
     "ethers": "^5.7.2",
     "framer-motion": "^10.11.2",
     "lodash": "^4.17.21",

--- a/garage/src/App.tsx
+++ b/garage/src/App.tsx
@@ -21,6 +21,7 @@ import { GlobalFlyParkModals } from "./components/GlobalFlyParkModals";
 import { RequiresWalletConnection } from "./components/RequiresWalletConnection";
 import { RigAttributeStatsContextProvider } from "./components/RigAttributeStatsContext";
 import { NFTsContextProvider } from "./components/NFTsContext";
+import { ActingAsAddressContextProvider } from "./components/ActingAsAddressContext";
 import { routes } from "./routes";
 import { chain } from "./env";
 
@@ -198,37 +199,39 @@ function App() {
       <ChakraProvider theme={theme}>
         <WagmiConfig client={wagmiClient}>
           <RainbowKitProvider chains={chains} theme={darkTheme()}>
-            <RigAttributeStatsContextProvider>
-              <NFTsContextProvider>
-                <BrowserRouter>
-                  <Topbar />
-                  <GlobalFlyParkModals>
-                    <Routes>
-                      {routes().map(
-                        (
-                          { requiresWalletConnection, element, ...props },
-                          index
-                        ) => (
-                          <Route
-                            {...props}
-                            key={`route-${index}`}
-                            element={
-                              requiresWalletConnection ? (
-                                <RequiresWalletConnection>
-                                  {element}
-                                </RequiresWalletConnection>
-                              ) : (
-                                element
-                              )
-                            }
-                          />
-                        )
-                      )}
-                    </Routes>
-                  </GlobalFlyParkModals>
-                </BrowserRouter>
-              </NFTsContextProvider>
-            </RigAttributeStatsContextProvider>
+            <ActingAsAddressContextProvider>
+              <RigAttributeStatsContextProvider>
+                <NFTsContextProvider>
+                  <BrowserRouter>
+                    <Topbar />
+                    <GlobalFlyParkModals>
+                      <Routes>
+                        {routes().map(
+                          (
+                            { requiresWalletConnection, element, ...props },
+                            index
+                          ) => (
+                            <Route
+                              {...props}
+                              key={`route-${index}`}
+                              element={
+                                requiresWalletConnection ? (
+                                  <RequiresWalletConnection>
+                                    {element}
+                                  </RequiresWalletConnection>
+                                ) : (
+                                  element
+                                )
+                              }
+                            />
+                          )
+                        )}
+                      </Routes>
+                    </GlobalFlyParkModals>
+                  </BrowserRouter>
+                </NFTsContextProvider>
+              </RigAttributeStatsContextProvider>
+            </ActingAsAddressContextProvider>
           </RainbowKitProvider>
         </WagmiConfig>
       </ChakraProvider>

--- a/garage/src/Topbar.tsx
+++ b/garage/src/Topbar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link as RouterLink, useNavigate } from "react-router-dom";
 import {
   Box,
   Button,
@@ -17,13 +17,20 @@ import {
   InputLeftElement,
   InputRightElement,
   Kbd,
+  Link,
   List,
   ListItem,
   Modal,
   ModalOverlay,
+  ModalBody,
+  ModalCloseButton,
   ModalContent,
+  ModalHeader,
+  RadioGroup,
+  Radio,
   Show,
   Spacer,
+  Stack,
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
@@ -35,6 +42,8 @@ import {
 import { ReactComponent as Logo } from "./assets/tableland.svg";
 import { useCurrentRoute } from "./hooks/useCurrentRoute";
 import { useKeysDown } from "./hooks/useKeysDown";
+import { useAccount } from "./hooks/useAccount";
+import { truncateWalletAddress } from "./utils/fmt";
 
 export const TOPBAR_HEIGHT = "80px";
 
@@ -176,7 +185,7 @@ const NavButton = ({ active, route, title, ref, ...rest }: NavButtonProps) => {
     <Button
       {...props}
       {...rest}
-      as={Link}
+      as={RouterLink}
       to={route}
       flexGrow="0"
       flexShrink="0"
@@ -239,8 +248,60 @@ const MobileDrawer = ({
   );
 };
 
+const ActAsModal = ({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) => {
+  const {
+    address,
+    delegations,
+    actingAsAddress,
+    setActingAsAddress,
+  } = useAccount();
+
+  const setValue = useCallback(
+    (value: string) => {
+      setActingAsAddress(value === address ? undefined : value);
+    },
+    [address, setActingAsAddress]
+  );
+  return (
+    <Modal size="md" isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Act as</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          The garage uses{" "}
+          <Link href="https://delegate.cash" isExternal>
+            delegate.cash
+          </Link>{" "}
+          to allow you to use your hot wallet(s) to manage Rigs in your vaults.
+          You have permission to act as:
+          <RadioGroup onChange={setValue} value={actingAsAddress} py={4}>
+            <Stack direction="column">
+              <Radio value={address}>Yourself</Radio>
+              {delegations.map(({ vault }, i) => {
+                return (
+                  <Radio value={vault} key={i}>
+                    {truncateWalletAddress(vault)}
+                  </Radio>
+                );
+              })}
+            </Stack>
+          </RadioGroup>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
 export const Topbar = () => {
   const route = useCurrentRoute();
+  const { delegations, actingAsAddress } = useAccount();
 
   const isEnter = route?.route.key === "ENTER";
   const bgColor = isEnter ? "primaryLight" : "primary";
@@ -254,6 +315,12 @@ export const Topbar = () => {
     isOpen: isDrawerOpen,
     onClose: onDrawerClose,
     onOpen: onDrawerOpen,
+  } = useDisclosure();
+
+  const {
+    isOpen: isActAsOpen,
+    onClose: onActAsClose,
+    onOpen: onActAsOpen,
   } = useDisclosure();
 
   return (
@@ -272,11 +339,11 @@ export const Topbar = () => {
         py={4}
       >
         <SearchModal isOpen={isSearchOpen} onClose={onSearchClose} />
-        <Link to="/dashboard">
+        <RouterLink to="/dashboard">
           <Box sx={{ maxWidth: { base: "50px", md: "98px" } }} mr={2}>
             <Logo width="100%" height="auto" />
           </Box>
-        </Link>
+        </RouterLink>
         <Show above="lg">
           <Text variant="orbitron" fontSize="20">
             Garage
@@ -316,6 +383,15 @@ export const Topbar = () => {
               </HStack>
               <HStack flexShrink="0" flexGrow="1" justify="end">
                 <RigSearchForm />
+                {delegations.length > 0 && (
+                  <Button
+                    {...inactiveProps}
+                    onClick={onActAsOpen}
+                    fontSize="xs"
+                  >
+                    Act as
+                  </Button>
+                )}
                 <TablelandConnectButton />
               </HStack>
             </Show>
@@ -341,6 +417,7 @@ export const Topbar = () => {
           </Flex>
         )}
       </Flex>
+      <ActAsModal isOpen={isActAsOpen} onClose={onActAsClose} />
     </>
   );
 };

--- a/garage/src/components/ActingAsAddressContext.tsx
+++ b/garage/src/components/ActingAsAddressContext.tsx
@@ -1,0 +1,39 @@
+import React, { useContext, useState, useMemo } from "react";
+
+interface ActingAsAddressContextValue {
+  actingAsAddress?: string;
+  setActingAsAddress: (address: string | undefined) => void;
+}
+
+const ActingAsAddressContext = React.createContext<
+  ActingAsAddressContextValue | undefined
+>(undefined);
+
+export const ActingAsAddressContextProvider = ({
+  children,
+}: React.PropsWithChildren<{}>) => {
+  const [actingAsAddress, setActingAsAddress] = useState<string>();
+
+  const value = useMemo(() => {
+    return { actingAsAddress, setActingAsAddress };
+  }, [actingAsAddress]);
+
+  return (
+    <ActingAsAddressContext.Provider value={value}>
+      {children}
+    </ActingAsAddressContext.Provider>
+  );
+};
+
+export const useActingAsAddressContext = () =>
+  useContext(ActingAsAddressContext);
+
+export const useActingAsAddress = () => {
+  const ctx = useActingAsAddressContext();
+
+  if (!ctx)
+    throw new Error("useActingAsAddress cannot be used outside of context");
+  const { actingAsAddress, setActingAsAddress } = ctx;
+
+  return { actingAsAddress, setActingAsAddress };
+};

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -37,11 +37,11 @@ import {
   chakraComponents,
 } from "chakra-react-select";
 import {
-  useAccount,
   useContractWrite,
   usePrepareContractWrite,
   useWaitForTransaction,
 } from "wagmi";
+import { useAccount } from "../hooks/useAccount";
 import {
   useOwnedNFTs,
   Collection,
@@ -507,7 +507,7 @@ const PickRigPilotStep = ({
   onNext,
   onClose,
 }: PickRigPilotStepProps) => {
-  const { address } = useAccount();
+  const { actingAsAddress } = useAccount();
   const { filters, toggleFilter, clearFilters } = useFilters<Collection>();
   const ownedNftsFilter = useMemo(() => {
     return {
@@ -521,7 +521,7 @@ const PickRigPilotStep = ({
   }, [ownedNftsFilter]);
 
   const { data, isFetching } = useOwnedNFTs(
-    address,
+    actingAsAddress,
     20,
     pagination.pages[pagination.index],
     ownedNftsFilter

--- a/garage/src/hooks/useAccount.ts
+++ b/garage/src/hooks/useAccount.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState } from "react";
+import { DelegateCash } from "delegatecash";
+import { useAccount as useWagmiAccount } from "wagmi";
+import { deployment } from "../env";
+import { isPresent } from "../utils/types";
+import { useActingAsAddress } from "../components/ActingAsAddressContext";
+
+const dc = new DelegateCash();
+
+type Flatten<Type> = Type extends Array<infer Item> ? Item : Type;
+
+type Delegation = Flatten<
+  Awaited<ReturnType<typeof dc.getDelegationsByDelegate>>
+>;
+
+const addressIsEqual = (a: string, b: string) =>
+  a.toLowerCase() === b.toLowerCase();
+
+export const useAccount = () => {
+  const account = useWagmiAccount();
+
+  const { actingAsAddress, setActingAsAddress } = useActingAsAddress();
+  const [delegations, setDelegations] = useState<Delegation[]>([]);
+
+  useEffect(() => {
+    setDelegations([]);
+
+    if (!account.address) return;
+
+    let isCancelled = false;
+
+    dc.getDelegationsByDelegate(account.address).then((result) => {
+      if (!isCancelled) {
+        setDelegations(
+          result.filter(
+            (v) =>
+              v.type === "ALL" ||
+              (v.type === "CONTRACT" &&
+                addressIsEqual(v.contract, deployment.contractAddress))
+          )
+        );
+      }
+    });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [account.address]);
+
+  const result = useMemo(() => {
+    let activeActingAddress = actingAsAddress ?? account?.address;
+
+    if (isPresent(actingAsAddress)) {
+      if (!delegations.find((v) => addressIsEqual(v.vault, actingAsAddress))) {
+        activeActingAddress = account?.address;
+      }
+    }
+
+    return {
+      ...account,
+      actingAsAddress: activeActingAddress,
+      setActingAsAddress,
+      delegations,
+    };
+  }, [account, actingAsAddress, delegations]);
+
+  return result;
+};

--- a/garage/src/pages/Dashboard/modules/RigsInventory.tsx
+++ b/garage/src/pages/Dashboard/modules/RigsInventory.tsx
@@ -18,7 +18,8 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 import { CheckIcon, QuestionIcon } from "@chakra-ui/icons";
-import { useAccount, useBlockNumber } from "wagmi";
+import { useBlockNumber } from "wagmi";
+import { useAccount } from "../../../hooks/useAccount";
 import { useOwnedRigs } from "../../../hooks/useOwnedRigs";
 import { useTablelandConnection } from "../../../hooks/useTablelandConnection";
 import { NFT } from "../../../hooks/useNFTs";
@@ -140,8 +141,8 @@ const isSelectable = (rig: Rig, selectable: Selectable): boolean => {
 };
 
 export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
-  const { address } = useAccount();
-  const { rigs, refresh } = useOwnedRigs(address);
+  const { address, actingAsAddress, delegations } = useAccount();
+  const { rigs, refresh } = useOwnedRigs(actingAsAddress);
   const { validator } = useTablelandConnection();
   const { data: currentBlockNumber } = useBlockNumber();
   const pilots = useMemo(() => {
@@ -314,13 +315,13 @@ export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
         </Flex>
       )}
 
-      {!rigs && address && (
+      {!rigs && actingAsAddress && (
         <Flex width="100%" height="200px" align="center" justify="center">
           <Spinner />
         </Flex>
       )}
 
-      {!address && (
+      {!actingAsAddress && (
         <Flex
           width="100%"
           height="200px"

--- a/garage/src/pages/Dashboard/modules/Stats.tsx
+++ b/garage/src/pages/Dashboard/modules/Stats.tsx
@@ -22,7 +22,7 @@ import {
   TabPanels,
   Text,
 } from "@chakra-ui/react";
-import { useAccount } from "wagmi";
+import { useAccount } from "../../../hooks/useAccount";
 import {
   useAccountStats,
   useStats,
@@ -108,9 +108,9 @@ const CollectionToplist = ({
 };
 
 export const Stats = (props: React.ComponentProps<typeof Box>) => {
-  const { address } = useAccount();
+  const { actingAsAddress } = useAccount();
   const { stats } = useStats();
-  const { stats: accountStats } = useAccountStats(address);
+  const { stats: accountStats } = useAccountStats(actingAsAddress);
   const { stats: pilotStats } = useTopActivePilotCollections();
   const { stats: ftStats } = useTopFtPilotCollections();
 
@@ -137,7 +137,7 @@ export const Stats = (props: React.ComponentProps<typeof Box>) => {
       <Tabs variant="line">
         <TabList>
           <Tab>Global</Tab>
-          {address && <Tab>You</Tab>}
+          {actingAsAddress && <Tab>You</Tab>}
           <Tab>Pilots</Tab>
         </TabList>
 
@@ -145,7 +145,7 @@ export const Stats = (props: React.ComponentProps<typeof Box>) => {
           <TabPanel px={0}>
             <StatGrid stats={stats} />
           </TabPanel>
-          {address && (
+          {actingAsAddress && (
             <TabPanel px={0}>
               <StatGrid stats={accountStats} />
             </TabPanel>

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -17,12 +17,8 @@ import {
 import { ethers } from "ethers";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 import { useParams, Link as RouterLink } from "react-router-dom";
-import {
-  useAccount,
-  useBlockNumber,
-  useContractReads,
-  useEnsName,
-} from "wagmi";
+import { useBlockNumber, useContractReads, useEnsName } from "wagmi";
+import { useAccount } from "../../hooks/useAccount";
 import { useGlobalFlyParkModals } from "../../components/GlobalFlyParkModals";
 import { ChainAwareButton } from "../../components/ChainAwareButton";
 import { RoundSvgIcon } from "../../components/RoundSvgIcon";
@@ -74,6 +70,7 @@ const RigHeader = ({
   ...props
 }: RigHeaderProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const { address, actingAsAddress } = useAccount();
   const totalFlightTime = rig.pilotSessions.reduce(
     (acc, { startTime, endTime }) => {
       return (
@@ -139,7 +136,7 @@ const RigHeader = ({
             </RouterLink>
           </Text>
 
-          {userOwnsRig && (
+          {userOwnsRig && address === actingAsAddress && (
             <ChainAwareButton
               variant="solid"
               color="primary"
@@ -158,7 +155,7 @@ const RigHeader = ({
 
 export const RigDetails = () => {
   const { id } = useParams();
-  const { address } = useAccount();
+  const { actingAsAddress } = useAccount();
   const { data: currentBlockNumber } = useBlockNumber();
   const { rig, refresh: refreshRig } = useRig(id || "");
   const { validator } = useTablelandConnection();
@@ -199,8 +196,11 @@ export const RigDetails = () => {
   }, [refreshRig, refetch]);
 
   const userOwnsRig = useMemo(() => {
-    return !!address && address.toLowerCase() === owner?.toLowerCase();
-  }, [address, owner]);
+    return (
+      !!actingAsAddress &&
+      actingAsAddress.toLowerCase() === owner?.toLowerCase()
+    );
+  }, [actingAsAddress, owner]);
 
   const [pendingTx, setPendingTx] = useState<string>();
   const clearPendingTx = useCallback(() => {


### PR DESCRIPTION
Updates the contract to allow a delegated wallet to train/pilot/park rigs using delegate.cash.
Adds a "Act as" button to the garage top header that is only shown if the currently connected wallet is registered as a delegate for a vault for the Rigs contract. A click on the button lets the user change wallet that they want to make actions for:

![image](https://user-images.githubusercontent.com/656107/229504113-c0a52873-28aa-4269-9889-0539444518d7.png)
![image](https://user-images.githubusercontent.com/656107/229504127-b88657a9-95f6-4a73-a9c1-2b4b1074f3e4.png)


Closes RIG-17