### PR TITLE
Garage: Add RigDetails train/pilot fix for rigs in inconsistent state

### DIFF
--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -40,7 +40,7 @@ import { prettyNumber, truncateWalletAddress } from "../../utils/fmt";
 import { sleep } from "../../utils/async";
 import { chain, openseaBaseUrl, deployment } from "../../env";
 import { RigWithPilots, isValidAddress } from "../../types";
-import { abi } from "../../abis/ERC721";
+import { abi } from "../../abis/TablelandRigs";
 import { ReactComponent as OpenseaMark } from "../../assets/opensea-mark.svg";
 import { ReactComponent as TablelandMark } from "../../assets/tableland.svg";
 
@@ -177,10 +177,16 @@ export const RigDetails = () => {
         functionName: "tokenURI",
         args: [ethers.BigNumber.from(id)],
       },
+      {
+        address: contractAddress,
+        abi,
+        functionName: "pilotInfo",
+        args: [ethers.BigNumber.from(id)],
+      },
     ],
   });
 
-  const [owner, tokenURI] = contractData ?? [];
+  const [owner, tokenURI, pilotInfo] = contractData ?? [];
 
   const pilots = useMemo(() => {
     return rig?.pilotSessions.filter((v) => v.contract);
@@ -322,6 +328,7 @@ export const RigDetails = () => {
                   onOpenParkModal={onOpenParkModal}
                   onOpenPilotModal={onOpenPilotModal}
                   onOpenTrainModal={onOpenTrainModal}
+                  chainPilotStatus={pilotInfo?.status}
                   {...MODULE_PROPS}
                 />
                 <FlightLog rig={rig} nfts={nfts} {...MODULE_PROPS} />

--- a/garage/src/pages/RigDetails/modules/Pilots.tsx
+++ b/garage/src/pages/RigDetails/modules/Pilots.tsx
@@ -27,6 +27,7 @@ import { useBlockNumber } from "wagmi";
 import { NFT } from "../../../hooks/useNFTs";
 import { findNFT } from "../../../utils/nfts";
 import { prettyNumber, pluralize } from "../../../utils/fmt";
+import { deployment } from "../../../env";
 
 const getPilots = (
   rig: RigWithPilots,
@@ -70,6 +71,7 @@ type PilotProps = React.ComponentProps<typeof Box> & {
   rig: RigWithPilots;
   nfts: NFT[];
   isOwner: boolean;
+  chainPilotStatus?: number;
   onOpenTrainModal: () => void;
   onOpenPilotModal: () => void;
   onOpenParkModal: () => void;
@@ -79,6 +81,7 @@ export const Pilots = ({
   rig,
   nfts,
   isOwner,
+  chainPilotStatus,
   onOpenTrainModal,
   onOpenPilotModal,
   onOpenParkModal,
@@ -189,7 +192,7 @@ export const Pilots = ({
       {isOwner && (
         <StackItem px={4}>
           <HStack gap={3}>
-            {!rig.currentPilot && !rig.isTrained && (
+            {!rig.currentPilot && (!rig.isTrained && chainPilotStatus !== 2) && (
               <ChainAwareButton
                 variant="outlined"
                 onClick={onOpenTrainModal}
@@ -198,10 +201,13 @@ export const Pilots = ({
                 Train
               </ChainAwareButton>
             )}
-            {(rig.isTrained || rig.currentPilot) && (
+            {(rig.isTrained || rig.currentPilot || chainPilotStatus === 2) && (
               <ChainAwareButton
                 variant="outlined"
-                isDisabled={!rig.isTrained || !!rig.currentPilot?.contract}
+                isDisabled={
+                  !!rig.currentPilot?.contract ||
+                  (!rig.isTrained && chainPilotStatus !== 2)
+                }
                 onClick={onOpenPilotModal}
                 width="100%"
               >


### PR DESCRIPTION
Updates the rig details page to make an on-chain call to `pilotInfo` and to take the contract state into account when deciding which train/pilot button to show. This PR doesn't change the dashboard so it will still show the incorrect action (train instead of pilot) if you select a rig in an inconsistent state, and batch piloting one of those rigs won't work.

Since we know that we only have 20 rigs in this state and we can get 9 fixed by working with one user I think this should be an OK solution. What do you think @sanderpick? 