### PR TITLE
Publish and bump rigs in animation_url and garage

### DIFF
--- a/animation_url/package-lock.json
+++ b/animation_url/package-lock.json
@@ -11,7 +11,7 @@
         "@playwright/test": "^1.27.1",
         "@sveltejs/adapter-auto": "^1.0.0-next.87",
         "@sveltejs/kit": "1.0.0-next.532",
-        "@tableland/rigs": "^0.1.4",
+        "@tableland/rigs": "^0.2.0",
         "@tableland/sdk": "^4.0.0",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
         "@typescript-eslint/parser": "^5.42.0",
@@ -1044,9 +1044,9 @@
       }
     },
     "node_modules/@tableland/rigs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.1.4.tgz",
-      "integrity": "sha512-O+0bs3arpjw8eMAi6b6zVtuCFiFNcTPhn/cCBRgHwJ8l3P2unGEHDox03/exhfqDUqGUGI2B/RhrmT5YtOBgBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.2.0.tgz",
+      "integrity": "sha512-wGYSxqaopQwEW1aNoObO4MS7LGsW7AYLGfP44akqbRB8CM6aLILBSWm0UC5rD7b1invS1Ve5qik+vGvKtt/9fw==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -5503,9 +5503,9 @@
       "dev": true
     },
     "@tableland/rigs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.1.4.tgz",
-      "integrity": "sha512-O+0bs3arpjw8eMAi6b6zVtuCFiFNcTPhn/cCBRgHwJ8l3P2unGEHDox03/exhfqDUqGUGI2B/RhrmT5YtOBgBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.2.0.tgz",
+      "integrity": "sha512-wGYSxqaopQwEW1aNoObO4MS7LGsW7AYLGfP44akqbRB8CM6aLILBSWm0UC5rD7b1invS1Ve5qik+vGvKtt/9fw==",
       "dev": true
     },
     "@tableland/sdk": {

--- a/animation_url/package.json
+++ b/animation_url/package.json
@@ -16,7 +16,7 @@
     "@playwright/test": "^1.27.1",
     "@sveltejs/adapter-auto": "^1.0.0-next.87",
     "@sveltejs/kit": "1.0.0-next.532",
-    "@tableland/rigs": "^0.1.4",
+    "@tableland/rigs": "^0.2.0",
     "@tableland/sdk": "^4.0.0",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.42.0",

--- a/ethereum/package-lock.json
+++ b/ethereum/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/rigs",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/rigs",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "Unlicense",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/rigs",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Tableland Rigs contract",
   "engines": {
     "node": ">=14.0.0"

--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -13,7 +13,7 @@
         "@emotion/react": "^11.10.4",
         "@emotion/styled": "^11.10.5",
         "@rainbow-me/rainbowkit": "^0.8.1",
-        "@tableland/rigs": "^0.1.4",
+        "@tableland/rigs": "^0.2.0",
         "@tableland/sdk": "^4.0.0-pre.8",
         "alchemy-sdk": "^2.2.5",
         "chakra-react-select": "^4.4.2",
@@ -3020,9 +3020,9 @@
       }
     },
     "node_modules/@tableland/rigs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.1.4.tgz",
-      "integrity": "sha512-O+0bs3arpjw8eMAi6b6zVtuCFiFNcTPhn/cCBRgHwJ8l3P2unGEHDox03/exhfqDUqGUGI2B/RhrmT5YtOBgBw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.2.0.tgz",
+      "integrity": "sha512-wGYSxqaopQwEW1aNoObO4MS7LGsW7AYLGfP44akqbRB8CM6aLILBSWm0UC5rD7b1invS1Ve5qik+vGvKtt/9fw==",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -9968,9 +9968,9 @@
       "integrity": "sha512-HftJLfg2x2R/f6l6PasrQ73Za071+2T6vmJV+p5PwPtXjlb5Pl+V7rtNWAIZgWE8cQY14lWUyhzw4P/+rrEcGA=="
     },
     "@tableland/rigs": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.1.4.tgz",
-      "integrity": "sha512-O+0bs3arpjw8eMAi6b6zVtuCFiFNcTPhn/cCBRgHwJ8l3P2unGEHDox03/exhfqDUqGUGI2B/RhrmT5YtOBgBw=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@tableland/rigs/-/rigs-0.2.0.tgz",
+      "integrity": "sha512-wGYSxqaopQwEW1aNoObO4MS7LGsW7AYLGfP44akqbRB8CM6aLILBSWm0UC5rD7b1invS1Ve5qik+vGvKtt/9fw=="
     },
     "@tableland/sdk": {
       "version": "4.0.0-pre.8",

--- a/garage/package.json
+++ b/garage/package.json
@@ -14,7 +14,7 @@
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.5",
     "@rainbow-me/rainbowkit": "^0.8.1",
-    "@tableland/rigs": "^0.1.4",
+    "@tableland/rigs": "^0.2.0",
     "@tableland/sdk": "^4.0.0-pre.8",
     "alchemy-sdk": "^2.2.5",
     "chakra-react-select": "^4.4.2",


### PR DESCRIPTION
Rigs interface changed in https://github.com/tablelandnetwork/rigs/pull/720, so we needed a publish to expose them in the garage.