### PR TITLE
Add publish workflow for npm package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,78 @@
+name: Publish
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: "Version of this release"
+        required: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Cache 📦
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Setup ⬢
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18
+
+      - name: Tag 🏷️
+        uses: actions/github-script@v5
+        id: create-tag
+        with:
+          github-token: ${{secrets.TEXTILEIO_MACHINE_ACCESS_TOKEN}}
+          script: |
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ github.event.inputs.release_version }}',
+              sha: context.sha
+            })
+
+      - name: Version 👍
+        id: version-bump
+        uses: jaywcjlove/github-action-package@v1.3.0
+        with:
+          version: ${{ github.event.inputs.release_version }}
+          path: ~/ethereum/package.json
+
+      - name: Install 🔧
+        run: cd ethereum && npm install
+
+      - name: Conditional ✅
+        id: cond
+        uses: haya14busa/action-cond@v1
+        with:
+          cond: ${{ contains(github.event.inputs.release_version, '-') }}
+          if_true: "next"
+          if_false: "latest"
+
+      - name: Publish 📦
+        id: publish
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_AUTH_TOKEN }}
+          tag: ${{ steps.cond.outputs.value }}
+          package: ~/ethereum
+          access: public
+          check-version: true
+
+      - name: Release 🚀
+        if: steps.publish.outputs.type != 'none'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.version }}
+          generateReleaseNotes: true
+          prerelease: ${{ contains(steps.publish.outputs.type, 'pre') }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds our standard publish workflow with one difference, the package root used by the actions is the `ethereum/` directory.

fixes https://linear.app/tableland/issue/RIG-33/rigs-npm-package-should-be-deployed-by-github-action
