### PR TITLE
feat: token reputation

### DIFF
--- a/ethereum/.openzeppelin/polygon-mumbai.json
+++ b/ethereum/.openzeppelin/polygon-mumbai.json
@@ -7126,6 +7126,450 @@
           }
         }
       }
+    },
+    "1a8175f1bdffb2459766bc6e6526cdfc3f16b8ccc354898425960307586168b8": {
+      "address": "0x8d810B8F4D41F2c8B454536B2a13a3ad492eaF32",
+      "txHash": "0xb7aaa75a211c6b90af32d9f6507f66b2b81ccc3aed9d54e9bdafa5150d7d1e1b",
+      "layout": {
+        "solcVersion": "0.8.19",
+        "storage": [
+          {
+            "label": "_uriParts",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_array(t_string_storage)dyn_storage",
+            "contract": "URITemplate",
+            "src": "contracts/utils/URITemplate.sol:13"
+          },
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "1",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "53",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "_paused",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_bool",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:29"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "PausableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol:116"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:80"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_defaultRoyaltyInfo",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_struct(RoyaltyInfo)1196_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:36"
+          },
+          {
+            "label": "_tokenRoyaltyInfo",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)1196_storage)",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:37"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_array(t_uint256)48_storage",
+            "contract": "ERC2981Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/common/ERC2981Upgradeable.sol:123"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "302",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:197"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "352",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "maxSupply",
+            "offset": 0,
+            "slot": "402",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:35"
+          },
+          {
+            "label": "mintPrice",
+            "offset": 0,
+            "slot": "403",
+            "type": "t_uint256",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:38"
+          },
+          {
+            "label": "beneficiary",
+            "offset": 0,
+            "slot": "404",
+            "type": "t_address_payable",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:41"
+          },
+          {
+            "label": "allowlistRoot",
+            "offset": 0,
+            "slot": "405",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:44"
+          },
+          {
+            "label": "waitlistRoot",
+            "offset": 0,
+            "slot": "406",
+            "type": "t_bytes32",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:47"
+          },
+          {
+            "label": "mintPhase",
+            "offset": 0,
+            "slot": "407",
+            "type": "t_enum(MintPhase)9374",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:50"
+          },
+          {
+            "label": "_contractInfoURI",
+            "offset": 0,
+            "slot": "408",
+            "type": "t_string_storage",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:53"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "409",
+            "type": "t_contract(ITablelandRigPilots)9346",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:56"
+          },
+          {
+            "label": "_allowTransferWhileFlying",
+            "offset": 20,
+            "slot": "409",
+            "type": "t_bool",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:59"
+          },
+          {
+            "label": "_admin",
+            "offset": 0,
+            "slot": "410",
+            "type": "t_address",
+            "contract": "TablelandRigs",
+            "src": "contracts/TablelandRigs.sol:62"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_address_payable": {
+            "label": "address payable",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_string_storage)dyn_storage": {
+            "label": "string[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)48_storage": {
+            "label": "uint256[48]",
+            "numberOfBytes": "1536"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ITablelandRigPilots)9346": {
+            "label": "contract ITablelandRigPilots",
+            "numberOfBytes": "20"
+          },
+          "t_enum(MintPhase)9374": {
+            "label": "enum ITablelandRigs.MintPhase",
+            "members": [
+              "CLOSED",
+              "ALLOWLIST",
+              "WAITLIST",
+              "PUBLIC"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)1196_storage)": {
+            "label": "mapping(uint256 => struct ERC2981Upgradeable.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoyaltyInfo)1196_storage": {
+            "label": "struct ERC2981Upgradeable.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyFraction",
+                "type": "t_uint96",
+                "offset": 20,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          },
+          "t_uint96": {
+            "label": "uint96",
+            "numberOfBytes": "12"
+          }
+        }
+      }
+    },
+    "cc98c3e99a2a84d9edbbf9ae0134f144f7f3af737d52cd0758620404177643c9": {
+      "address": "0x50Dfd8b90aB1dacD45aD885a8348557eE60AaFcD",
+      "txHash": "0x9d44d8b4d5d142a3dad3726208ea6caa92cf0120fd23275e8853f79b7b1e364f",
+      "layout": {
+        "solcVersion": "0.8.19",
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC1967UpgradeUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/ERC1967/ERC1967UpgradeUpgradeable.sol:197"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "UUPSUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol:107"
+          },
+          {
+            "label": "_parent",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:42"
+          },
+          {
+            "label": "_pilotSessionsTableId",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_uint256",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:45"
+          },
+          {
+            "label": "_pilots",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_mapping(t_uint16,t_uint256)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:53"
+          },
+          {
+            "label": "_pilotIndex",
+            "offset": 0,
+            "slot": "204",
+            "type": "t_mapping(t_uint192,t_uint16)",
+            "contract": "TablelandRigPilots",
+            "src": "contracts/TablelandRigPilots.sol:57"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_uint16,t_uint256)": {
+            "label": "mapping(uint16 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint192,t_uint16)": {
+            "label": "mapping(uint192 => uint16)",
+            "numberOfBytes": "32"
+          },
+          "t_uint16": {
+            "label": "uint16",
+            "numberOfBytes": "2"
+          },
+          "t_uint192": {
+            "label": "uint192",
+            "numberOfBytes": "24"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }

--- a/ethereum/contracts/ITablelandRigPilots.sol
+++ b/ethereum/contracts/ITablelandRigPilots.sol
@@ -19,8 +19,6 @@ interface ITablelandRigPilots {
 
     // Values describing a Rig's Garage status.
     enum GarageStatus {
-        UNTRAINED,
-        TRAINING,
         PARKED,
         PILOTED
     }
@@ -40,19 +38,18 @@ interface ITablelandRigPilots {
     }
 
     /**
-     * @dev Emitted when a Rig starts its training.
-     */
-    event Training(uint256 tokenId);
-
-    /**
      * @dev Emitted when a Rig is piloted.
      */
-    event Piloted(uint256 tokenId, address pilotContract, uint256 pilotId);
+    event Piloted(
+        uint256 indexed tokenId,
+        address indexed pilotContract,
+        uint256 indexed pilotId
+    );
 
     /**
      * @dev Emitted when a Rig is parked.
      */
-    event Parked(uint256 tokenId);
+    event Parked(uint256 indexed tokenId);
 
     /**
      * @dev Returns the address of the contract parent parent.
@@ -85,21 +82,7 @@ interface ITablelandRigPilots {
     function pilotStartTime(uint256 tokenId) external view returns (uint64);
 
     /**
-     * @dev Trains a Rig for a period of 30 days, putting it in-flight.
-     *
-     * sender - the initiator address
-     * tokenId - the unique Rig token identifier
-     *
-     * Requirements:
-     *
-     * - `sender` must own the Rig
-     * - `tokenId` must exist
-     * - pilot status must be valid (`UNTRAINED`)
-     */
-    function trainRig(address sender, uint256 tokenId) external;
-
-    /**
-     * @dev Puts a single Rig in flight with a "stock" trainer pilot.
+     * @dev Puts a single Rig in flight with a "stock" pilot.
      *
      * sender - the initiator address
      * tokenId - the unique Rig token identifier
@@ -108,7 +91,7 @@ interface ITablelandRigPilots {
      *
      * - `tokenId` must exist
      * - `sender` must own the Rig
-     * - Must already be trained & currently parked
+     * - Must currently be parked
      */
     function pilotRig(address sender, uint256 tokenId) external;
 
@@ -124,7 +107,7 @@ interface ITablelandRigPilots {
      *
      * - `tokenId` must exist
      * - `sender` must own the Rig
-     * - Ability to pilot must be `true` (trained & flying with trainer, or already trained & parked)
+     * - Ability to pilot must be `true` (flying with stock pilot, or currently parked)
      * - `pilotContract` must be an ERC-721 contract; cannot be the Rigs contract
      * - `pilotId` must be owned by `msg.sender` at `pilotContract`
      * - `Pilot` can only be associated with one Rig at a time; parks the other Rig on conflict
@@ -146,8 +129,7 @@ interface ITablelandRigPilots {
      *
      * - `tokenId` must exist
      * - `sender` must own the Rig
-     * - pilot status must be `TRAINING` or `PILOTED`
-     * - pilot must have completed 30 days of training
+     * - pilot status must `PILOTED`
      */
     function parkRig(uint256 tokenId, bool force) external;
 

--- a/ethereum/contracts/ITablelandRigs.sol
+++ b/ethereum/contracts/ITablelandRigs.sol
@@ -217,18 +217,6 @@ interface ITablelandRigs {
     ) external view returns (ITablelandRigPilots.PilotInfo[] memory);
 
     /**
-     * @dev Trains a single Rig for a period of 30 days, putting it in-flight.
-     *
-     * tokenId - the unique Rig token identifier
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist
-     * - pilot status must be valid (`UNTRAINED`)
-     */
-    function trainRig(uint256 tokenId) external;
-
-    /**
      * @dev Puts multiple Rigs in training.
      *
      * tokenIds - the unique Rig token identifier
@@ -241,7 +229,7 @@ interface ITablelandRigs {
      * - Values are processed in order
      * - See `trainRig` for additional constraints on a per-token basis
      */
-    function trainRig(uint256[] calldata tokenIds) external;
+    function stake(uint256[] calldata tokenIds) external;
 
     /**
      * @dev Puts a single Rig in flight by setting a custom pilot.
@@ -259,7 +247,7 @@ interface ITablelandRigs {
      * - `pilotId` must be owned by `msg.sender` at `pilotContract` (does not apply to trainer pilots)
      * - Pilot can only be associated with one Rig at a time; parks the other Rig on conflict (does not apply to trainer pilots)
      */
-    function pilotRig(
+    function stake(
         uint256 tokenId,
         address pilotContract,
         uint256 pilotId
@@ -279,26 +267,13 @@ interface ITablelandRigs {
      * - There cannot exist a duplicate value in each of the individual parameters,
      *   except if using a trainer pilot (i.e., trainers aren't unique/owned NFTs).
      * - Values are processed in order (i.e., use same index for each array)
-     * - See `pilotRig` for additional constraints on a per-token basis
+     * - See `stake` for additional constraints on a per-token basis
      */
-    function pilotRig(
+    function stake(
         uint256[] calldata tokenIds,
         address[] calldata pilotContracts,
         uint256[] calldata pilotIds
     ) external;
-
-    /**
-     * @dev Parks a single Rig and ends the current pilot session.
-     *
-     * tokenId - the unique Rig token identifier
-     *
-     * Requirements:
-     *
-     * - `tokenId` must exist
-     * - pilot status must be `TRAINING` or `PILOTED`
-     * - pilot must have completed 30 days of training
-     */
-    function parkRig(uint256 tokenId) external;
 
     /**
      * @dev Parks multiple Rigs and ends the current pilot session.
@@ -312,7 +287,7 @@ interface ITablelandRigs {
      * - Values are processed in order
      * - See `parkRig` for additional constraints on a per-token basis
      */
-    function parkRig(uint256[] calldata tokenIds) external;
+    function unstake(uint256[] calldata tokenIds) external;
 
     /**
      * @dev Allows contract owner to park any Rig that may be intentionally

--- a/ethereum/contracts/TablelandRigPilots.sol
+++ b/ethereum/contracts/TablelandRigPilots.sol
@@ -243,8 +243,6 @@ contract TablelandRigPilots is
                 )
             )
         );
-
-        emit Piloted(tokenId, address(0), 1);
     }
 
     /**
@@ -317,8 +315,6 @@ contract TablelandRigPilots is
         // Update the pilot data and index
         _setPilotData(uint16(tokenId), uint160(pilotAddr), uint32(pilotId));
         _pilotIndex[pilotData] = uint16(tokenId);
-
-        emit Piloted(tokenId, pilotAddr, pilotId);
     }
 
     /**
@@ -372,8 +368,6 @@ contract TablelandRigPilots is
                 filters
             )
         );
-
-        emit Parked(tokenId);
     }
 
     /**

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -517,7 +517,7 @@ contract TablelandRigs is
         // Check the Rig `tokenId` exists
         if (!_exists(tokenId)) revert OwnerQueryForNonexistentToken();
 
-        // Verify `msg.sender` is authorized to pilot the specified Rig
+        // Verify `msg.sender` is authorized to stake the specified Rig
         (
             address tokenOwner,
             address sender
@@ -530,7 +530,9 @@ contract TablelandRigs is
         pilotAddr == address(0)
             ? _pilots.pilotRig(sender, tokenId)
             : _pilots.pilotRig(sender, tokenId, pilotAddr, pilotId);
-        emit Stake(tokenId, tokenOwner);
+
+        // Depending on the caller, emit either the token's owner or operator
+        emit Stake(tokenId, msg.sender);
         emit MetadataUpdate(tokenId);
     }
 
@@ -580,7 +582,9 @@ contract TablelandRigs is
 
         // Pass `false` to indicate a standard (non-force) park
         _pilots.parkRig(tokenId, false);
-        emit Unstake(tokenId, tokenOwner);
+
+        // Depending on the `msg.sender`, emit either the token's owner or operator
+        emit Unstake(tokenId, msg.sender);
         emit MetadataUpdate(tokenId);
     }
 
@@ -593,7 +597,7 @@ contract TablelandRigs is
         if (tokenIds.length == 0 || tokenIds.length > type(uint8).max)
             revert ITablelandRigPilots.InvalidBatchPilotAction();
 
-        // For each token, call `parkRig`
+        // For each token, call `unstake`
         for (uint8 i = 0; i < tokenIds.length; i++) {
             unstake(tokenIds[i]);
         }

--- a/ethereum/contracts/TablelandRigs.sol
+++ b/ethereum/contracts/TablelandRigs.sol
@@ -530,7 +530,7 @@ contract TablelandRigs is
         pilotAddr == address(0)
             ? _pilots.pilotRig(sender, tokenId)
             : _pilots.pilotRig(sender, tokenId, pilotAddr, pilotId);
-        emit Stake(tokenId, tokenOwner, block.number);
+        emit Stake(tokenId, tokenOwner);
         emit MetadataUpdate(tokenId);
     }
 
@@ -580,7 +580,7 @@ contract TablelandRigs is
 
         // Pass `false` to indicate a standard (non-force) park
         _pilots.parkRig(tokenId, false);
-        emit Unstake(tokenId, tokenOwner, block.number);
+        emit Unstake(tokenId, tokenOwner);
         emit MetadataUpdate(tokenId);
     }
 
@@ -617,7 +617,7 @@ contract TablelandRigs is
             if (!_exists(tokenIds[i])) revert OwnerQueryForNonexistentToken();
             // Pass `true` to indicate a force park
             _pilots.parkRig(tokenIds[i], true);
-            emit Unstake(tokenIds[i], ownerOf(tokenIds[i]), block.number);
+            emit Unstake(tokenIds[i], ownerOf(tokenIds[i]));
             emit MetadataUpdate(tokenIds[i]);
         }
     }

--- a/ethereum/contracts/interfaces/ITokenReputation.sol
+++ b/ethereum/contracts/interfaces/ITokenReputation.sol
@@ -9,25 +9,15 @@ interface ITokenReputation {
      * @notice Emitted when token staking is initiated.
      * @param tokenId Identifier for the token being staked.
      * @param owner The token owner who wants to stake the token.
-     * @param block The block number at the time of staking.
      */
-    event Stake(
-        uint256 indexed tokenId,
-        address indexed owner,
-        uint256 indexed block
-    );
+    event Stake(uint256 indexed tokenId, address indexed owner);
 
     /**
      * @notice Emitted when token unstaking is initiated.
      * @param tokenId Identifier for the token being unstaked.
      * @param owner The token owner who wants to unstake the token.
-     * @param block The block number at the time of unstaking.
      */
-    event Unstake(
-        uint256 indexed tokenId,
-        address indexed owner,
-        uint256 indexed block
-    );
+    event Unstake(uint256 indexed tokenId, address indexed owner);
 
     /**
      * @notice Stake the token, disabling marketplace transfers.

--- a/ethereum/contracts/interfaces/ITokenReputation.sol
+++ b/ethereum/contracts/interfaces/ITokenReputation.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+/**
+ * @title A minimal ERC-721 extension for token-based reputation.
+ */
+interface ITokenReputation {
+    /**
+     * @notice Emitted when token staking is initiated.
+     * @param tokenId Identifier for the token being staked.
+     * @param owner The token owner who wants to stake the token.
+     * @param block The block number at the time of staking.
+     */
+    event Stake(
+        uint256 indexed tokenId,
+        address indexed owner,
+        uint256 indexed block
+    );
+
+    /**
+     * @notice Emitted when token unstaking is initiated.
+     * @param tokenId Identifier for the token being unstaked.
+     * @param owner The token owner who wants to unstake the token.
+     * @param block The block number at the time of unstaking.
+     */
+    event Unstake(
+        uint256 indexed tokenId,
+        address indexed owner,
+        uint256 indexed block
+    );
+
+    /**
+     * @notice Stake the token, disabling marketplace transfers.
+     * @param tokenId The unique token identifier.
+     */
+    function stake(uint256 tokenId) external;
+
+    /**
+     * @notice Unstake the token, enabling marketplace transfers.
+     * @param tokenId The unique token identifier.
+     */
+    function unstake(uint256 tokenId) external;
+}

--- a/ethereum/contracts/interfaces/ITokenReputation.sol
+++ b/ethereum/contracts/interfaces/ITokenReputation.sol
@@ -8,16 +8,16 @@ interface ITokenReputation {
     /**
      * @notice Emitted when token staking is initiated.
      * @param tokenId Identifier for the token being staked.
-     * @param owner The token owner who wants to stake the token.
+     * @param operator The token owner/operator who wants to stake the token.
      */
-    event Stake(uint256 indexed tokenId, address indexed owner);
+    event Stake(uint256 indexed tokenId, address indexed operator);
 
     /**
      * @notice Emitted when token unstaking is initiated.
      * @param tokenId Identifier for the token being unstaked.
-     * @param owner The token owner who wants to unstake the token.
+     * @param operator The token owner/operator who wants to unstake the token.
      */
-    event Unstake(uint256 indexed tokenId, address indexed owner);
+    event Unstake(uint256 indexed tokenId, address indexed operator);
 
     /**
      * @notice Stake the token, disabling marketplace transfers.

--- a/ethereum/deployments.ts
+++ b/ethereum/deployments.ts
@@ -54,9 +54,9 @@ export const deployments: RigsDeployments = {
   },
   // testnets
   "polygon-mumbai": {
-    contractAddress: "0x36Ae6D7e2B460530A22416C8fC8A506cADE353B8",
+    contractAddress: "0xfdD15E0Af08AF6b767bc85384698eda79f5AcAb4",
     royaltyContractAddress: "0xb61974afD4348DA16e45BC48d53883A281bc4A6e",
-    pilotsAddress: "0x171c03D706f02Ed57f8509539ED590A69d286D61",
+    pilotsAddress: "0x864655946432f52AE16BDE9af054380b3dE06789",
     tablelandChain: "maticmum",
     tablelandHost: "https://testnets.tableland.network",
     contractTable: "rigs_contract_80001_3819",

--- a/ethereum/test/TablelandRigPilots.ts
+++ b/ethereum/test/TablelandRigPilots.ts
@@ -1,5 +1,7 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+import "@nomicfoundation/hardhat-toolbox";
+import "@openzeppelin/hardhat-upgrades";
 import { TablelandTables } from "@tableland/evm";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -73,16 +75,6 @@ describe("Pilots", function () {
     });
   });
 
-  describe("trainRig", function () {
-    it("Should only allow contract parent", async function () {
-      const _pilots = pilots.connect(accounts[2]);
-
-      await expect(
-        _pilots.trainRig(ethers.constants.AddressZero, BigNumber.from(1))
-      ).to.be.rejectedWith("Pilots: caller is not the parent");
-    });
-  });
-
   describe("pilotRig", function () {
     it("Should only allow contract parent", async function () {
       const _pilots = pilots.connect(accounts[2]);
@@ -110,7 +102,7 @@ describe("Pilots", function () {
       const _pilots = pilots.connect(accounts[2]);
 
       await expect(
-        _pilots.parkRig(ethers.constants.AddressZero, BigNumber.from(1))
+        _pilots.parkRig(ethers.constants.AddressZero, true)
       ).to.be.rejectedWith("Pilots: caller is not the parent");
     });
   });

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -794,19 +794,19 @@ describe("Rigs", function () {
       });
     });
 
-    describe("trainRig", function () {
+    describe("stake", function () {
       it("Should not train Rig when paused", async function () {
         await rigs.pause();
         // Try to train a single Rig when paused
         const sender = accounts[4];
         await expect(
-          rigs.connect(sender)["trainRig(uint256)"](BigNumber.from(0))
+          rigs.connect(sender)["stake(uint256)"](BigNumber.from(0))
         ).to.be.revertedWith("Pausable: paused");
         // Try to train a multiple Rigs when paused
         await expect(
           rigs
             .connect(sender)
-            ["trainRig(uint256[])"]([BigNumber.from(0), BigNumber.from(0)])
+            ["stake(uint256[])"]([BigNumber.from(0), BigNumber.from(0)])
         ).to.be.revertedWith("Pausable: paused");
 
         await rigs.unpause();
@@ -814,7 +814,7 @@ describe("Rigs", function () {
 
       it("Should not train Rig for non-existent token", async function () {
         await expect(
-          rigs["trainRig(uint256)"](BigNumber.from(0))
+          rigs["stake(uint256)"](BigNumber.from(0))
         ).to.be.rejectedWith("OwnerQueryForNonexistentToken");
       });
 
@@ -831,7 +831,7 @@ describe("Rigs", function () {
         // Attempt to train the Rig with an address that doesn't own the token
         const sender = accounts[5];
         await expect(
-          rigs.connect(sender)["trainRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(sender)["stake(uint256)"](BigNumber.from(tokenId))
         ).to.be.rejectedWith("Unauthorized");
       });
 
@@ -847,7 +847,7 @@ describe("Rigs", function () {
         const tokenId = event.args?.tokenId;
         // Train the Rig
         await expect(
-          rigs.connect(tokenOwner)["trainRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
         )
           .to.emit(pilots, "Training")
           .withArgs(BigNumber.from(tokenId));
@@ -866,10 +866,10 @@ describe("Rigs", function () {
         // Train the Rig
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Try to train the Rig again
         await expect(
-          rigs.connect(tokenOwner)["trainRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
         ).to.be.rejectedWith("InvalidPilotStatus");
       });
 
@@ -893,7 +893,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["trainRig(uint256[])"]([
+            ["stake(uint256[])"]([
               BigNumber.from(tokenId1),
               BigNumber.from(tokenId2),
             ])
@@ -918,7 +918,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["trainRig(uint256[])"]([
+            ["stake(uint256[])"]([
               BigNumber.from(tokenId),
               BigNumber.from(tokenId),
             ])
@@ -930,12 +930,12 @@ describe("Rigs", function () {
 
       it("Should not batch train Rig with empty array or exceeding max length for array", async function () {
         // Try with an empty array
-        await expect(rigs["trainRig(uint256[])"]([])).to.be.rejectedWith(
+        await expect(rigs["stake(uint256[])"]([])).to.be.rejectedWith(
           "InvalidBatchPilotAction"
         );
         // Try with an array of tokens exceeding 255 in length (the arbitrary limit)
         const tokenIds = [...Array(256).keys()];
-        await expect(rigs["trainRig(uint256[])"](tokenIds)).to.be.rejectedWith(
+        await expect(rigs["stake(uint256[])"](tokenIds)).to.be.rejectedWith(
           "InvalidBatchPilotAction"
         );
       });
@@ -947,14 +947,14 @@ describe("Rigs", function () {
 
         // Try to pilot when paused
         await expect(
-          rigs["pilotRig(uint256,address,uint256)"](
+          rigs["stake(uint256,address,uint256)"](
             BigNumber.from(0),
             ethers.constants.AddressZero,
             BigNumber.from(1)
           )
         ).to.be.rejectedWith("Pausable: paused");
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [ethers.constants.AddressZero],
             [BigNumber.from(1)]
@@ -967,7 +967,7 @@ describe("Rigs", function () {
       it("Should not pilot Rig for non-existent token", async function () {
         // Try with a single Rig and `pilotRig`
         await expect(
-          rigs["pilotRig(uint256,address,uint256)"](
+          rigs["stake(uint256,address,uint256)"](
             BigNumber.from(0),
             ethers.constants.AddressZero,
             BigNumber.from(1)
@@ -975,7 +975,7 @@ describe("Rigs", function () {
         ).to.be.rejectedWith("OwnerQueryForNonexistentToken");
         // Try with multiple Rigs and `pilotRig` (batch)
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [ethers.constants.AddressZero],
             [BigNumber.from(1)]
@@ -998,7 +998,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(sender)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               ethers.constants.AddressZero,
               BigNumber.from(1)
@@ -1018,7 +1018,7 @@ describe("Rigs", function () {
         const tokenId = event.args?.tokenId;
         // Attempt to pilot the Rig with too big pilot id
         await expect(
-          rigs.connect(tokenOwner)["pilotRig(uint256,address,uint256)"](
+          rigs.connect(tokenOwner)["stake(uint256,address,uint256)"](
             BigNumber.from(tokenId),
             ethers.utils.hexZeroPad(1, 20), // 0x0...01
             BigNumber.from(Math.pow(2, 32))
@@ -1039,14 +1039,14 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
         ]);
         // Try to set the pilot to a non-ERC721 address
         await expect(
-          rigs.connect(tokenOwner)["pilotRig(uint256,address,uint256)"](
+          rigs.connect(tokenOwner)["stake(uint256,address,uint256)"](
             BigNumber.from(tokenId),
             ethers.utils.hexZeroPad(1, 20), // 0x0...01
             BigNumber.from(1)
@@ -1058,7 +1058,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               rigs.address,
               BigNumber.from(1)
@@ -1091,7 +1091,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               fauxERC721.address,
               pilotTokenIdRigOwner
@@ -1100,12 +1100,12 @@ describe("Rigs", function () {
         // Train the Rig
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Attempt to pilot the Rig again, while in-flight but training incomplete
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               fauxERC721.address,
               pilotTokenIdRigOwner
@@ -1126,7 +1126,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(rigTokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+          ["stake(uint256)"](BigNumber.from(rigTokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1134,7 +1134,7 @@ describe("Rigs", function () {
         // Park the Rig now that training has been completed
         await rigs
           .connect(rigTokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId));
         // Deploy a faux ERC-721 token but mint to an address *not* `rigTokenOwner`
         const FauxERC721Factory = await ethers.getContractFactory(
           "TestERC721Enumerable"
@@ -1149,7 +1149,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(rigTokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(rigTokenId),
               fauxERC721.address,
               pilotTokenIdRandomPilotTokenHolder
@@ -1163,7 +1163,7 @@ describe("Rigs", function () {
         await expect(
           await rigs
             .connect(rigTokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(rigTokenId),
               fauxERC721.address,
               pilotTokenIdRigOwner
@@ -1179,7 +1179,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(rigTokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(rigTokenId),
               fauxERC721.address,
               pilotTokenIdRigOwner
@@ -1209,7 +1209,7 @@ describe("Rigs", function () {
         // Start to train the Rig
         tx = await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+          ["stake(uint256)"](BigNumber.from(rigTokenId));
         // Save the block number, which will used when checking if a training Rig remains in-flight when piloted
         let blockNumber = tx.blockNumber;
         // Check the pilot info
@@ -1228,7 +1228,7 @@ describe("Rigs", function () {
         // Pilot the Rig while in-flight since training is complete
         tx = await rigs
           .connect(tokenOwner)
-          ["pilotRig(uint256,address,uint256)"](
+          ["stake(uint256,address,uint256)"](
             BigNumber.from(rigTokenId),
             fauxERC721.address,
             pilotTokenId
@@ -1254,7 +1254,7 @@ describe("Rigs", function () {
         // Park the Rig, now that training has completed
         await rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId));
         // Check the pilot info
         pilotInfo = await rigs["pilotInfo(uint256)"](
           BigNumber.from(rigTokenId)
@@ -1267,7 +1267,7 @@ describe("Rigs", function () {
         // Pilot the Rig with the same pilot, used before parking
         tx = await rigs
           .connect(tokenOwner)
-          ["pilotRig(uint256,address,uint256)"](
+          ["stake(uint256,address,uint256)"](
             BigNumber.from(rigTokenId),
             fauxERC721.address,
             pilotTokenId
@@ -1293,7 +1293,7 @@ describe("Rigs", function () {
         // Park, then pilot with a new pilot from a new, different faux NFT contract
         await rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId));
         const fauxTwoERC721 = await (
           await FauxERC721Factory.deploy()
         ).deployed();
@@ -1304,7 +1304,7 @@ describe("Rigs", function () {
         // Pilot with the new, unused "FauxTwo" pilot
         tx = await rigs
           .connect(tokenOwner)
-          ["pilotRig(uint256,address,uint256)"](
+          ["stake(uint256,address,uint256)"](
             BigNumber.from(rigTokenId),
             fauxTwoERC721.address,
             pilotTokenId
@@ -1342,7 +1342,7 @@ describe("Rigs", function () {
         // Start to train the Rig
         tx = await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1351,7 +1351,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               ethers.constants.AddressZero,
               2
@@ -1372,7 +1372,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(rigTokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1380,16 +1380,14 @@ describe("Rigs", function () {
         // Park the Rig now that training has been completed
         await rigs
           .connect(rigTokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(tokenId));
+          ["unstake(uint256)"](BigNumber.from(tokenId));
         // Set the pilot to a trainer
         await expect(
-          await rigs
-            .connect(rigTokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
-              BigNumber.from(tokenId),
-              ethers.constants.AddressZero,
-              BigNumber.from(2) // Pilot ID value doesn't matter
-            )
+          await rigs.connect(rigTokenOwner)["stake(uint256,address,uint256)"](
+            BigNumber.from(tokenId),
+            ethers.constants.AddressZero,
+            BigNumber.from(2) // Pilot ID value doesn't matter
+          )
         )
           .to.emit(pilots, "Piloted")
           .withArgs(
@@ -1418,10 +1416,10 @@ describe("Rigs", function () {
         // Train both Rigs, putting them in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId1));
+          ["stake(uint256)"](BigNumber.from(rigTokenId1));
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["stake(uint256)"](BigNumber.from(rigTokenId2));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1429,10 +1427,10 @@ describe("Rigs", function () {
         // Park the Rigs now that training has been completed
         await rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId1));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId1));
         await rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId2));
         // Deploy a faux ERC721 token and mint a token to `tokenOwner`
         const FauxERC721Factory = await ethers.getContractFactory(
           "TestERC721Enumerable"
@@ -1445,7 +1443,7 @@ describe("Rigs", function () {
         // Set the pilot for the first Rig
         await rigs
           .connect(tokenOwner)
-          ["pilotRig(uint256,address,uint256)"](
+          ["stake(uint256,address,uint256)"](
             BigNumber.from(rigTokenId1),
             fauxERC721.address,
             pilotTokenId
@@ -1454,7 +1452,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(rigTokenId2),
               fauxERC721.address,
               pilotTokenId
@@ -1473,17 +1471,17 @@ describe("Rigs", function () {
       it("Should not batch pilot Rigs for empty, unequal length, or max length for arrays", async function () {
         // Try to send empty arrays
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"]([], [], [])
+          rigs["stake(uint256[],address[],uint256[])"]([], [], [])
         ).to.be.rejectedWith("InvalidBatchPilotAction");
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [],
             []
           )
         ).to.be.rejectedWith("InvalidBatchPilotAction");
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [ethers.constants.AddressZero],
             []
@@ -1491,21 +1489,21 @@ describe("Rigs", function () {
         ).to.be.rejectedWith("InvalidBatchPilotAction");
         // Try to send arrays of unequal lengths
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0), BigNumber.from(0)],
             [ethers.constants.AddressZero],
             [BigNumber.from(1)]
           )
         ).to.be.rejectedWith("InvalidBatchPilotAction");
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [ethers.constants.AddressZero, ethers.constants.AddressZero],
             [BigNumber.from(1)]
           )
         ).to.be.rejectedWith("InvalidBatchPilotAction");
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             [BigNumber.from(0)],
             [ethers.constants.AddressZero],
             [BigNumber.from(1), BigNumber.from(2)]
@@ -1518,7 +1516,7 @@ describe("Rigs", function () {
         );
         const pilotIds = [...Array(256).keys()];
         await expect(
-          rigs["pilotRig(uint256[],address[],uint256[])"](
+          rigs["stake(uint256[],address[],uint256[])"](
             tokenIds,
             pilotContracts,
             pilotIds
@@ -1545,10 +1543,10 @@ describe("Rigs", function () {
         // Train both Rigs, putting them in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId1));
+          ["stake(uint256)"](BigNumber.from(rigTokenId1));
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["stake(uint256)"](BigNumber.from(rigTokenId2));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1566,7 +1564,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256[],address[],uint256[])"](
+            ["stake(uint256[],address[],uint256[])"](
               [BigNumber.from(rigTokenId1), BigNumber.from(rigTokenId2)],
               [fauxERC721.address, fauxERC721.address],
               [pilotTokenId, pilotTokenId]
@@ -1607,12 +1605,12 @@ describe("Rigs", function () {
         // Park the second Rig that's in-flight
         rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId2));
         // Set the same pilot for both Rigs -- should pilot then park the first, and then pilot the second
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256[],address[],uint256[])"](
+            ["stake(uint256[],address[],uint256[])"](
               [BigNumber.from(rigTokenId1), BigNumber.from(rigTokenId2)],
               [fauxERC721.address, fauxERC721.address],
               [pilotTokenId, pilotTokenId]
@@ -1677,13 +1675,13 @@ describe("Rigs", function () {
         // Train all Rigs, putting them in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId1));
+          ["stake(uint256)"](BigNumber.from(rigTokenId1));
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["stake(uint256)"](BigNumber.from(rigTokenId2));
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId3));
+          ["stake(uint256)"](BigNumber.from(rigTokenId3));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -1691,10 +1689,10 @@ describe("Rigs", function () {
         // Park the second and third Rigs that are in-flight
         rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId2));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId2));
         rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(rigTokenId3));
+          ["unstake(uint256)"](BigNumber.from(rigTokenId3));
         // Deploy a faux ERC721 token and mint a token to `tokenOwner`
         const FauxERC721Factory = await ethers.getContractFactory(
           "TestERC721Enumerable"
@@ -1709,7 +1707,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256[],address[],uint256[])"](
+            ["stake(uint256[],address[],uint256[])"](
               [
                 BigNumber.from(rigTokenId1),
                 BigNumber.from(rigTokenId2),
@@ -1775,13 +1773,13 @@ describe("Rigs", function () {
         // Try to park a single Rig when paused
         const sender = accounts[4];
         await expect(
-          rigs.connect(sender)["parkRig(uint256)"](BigNumber.from(0))
+          rigs.connect(sender)["unstake(uint256)"](BigNumber.from(0))
         ).to.be.revertedWith("Pausable: paused");
         // Try to park a multiple Rigs when paused
         await expect(
           rigs
             .connect(sender)
-            ["parkRig(uint256[])"]([BigNumber.from(0), BigNumber.from(0)])
+            ["unstake(uint256[])"]([BigNumber.from(0), BigNumber.from(0)])
         ).to.be.revertedWith("Pausable: paused");
 
         await rigs.unpause();
@@ -1789,7 +1787,7 @@ describe("Rigs", function () {
 
       it("Should not park Rig for non-existent token", async function () {
         await expect(
-          rigs["parkRig(uint256)"](BigNumber.from(0))
+          rigs["unstake(uint256)"](BigNumber.from(0))
         ).to.be.rejectedWith("OwnerQueryForNonexistentToken");
       });
 
@@ -1806,7 +1804,7 @@ describe("Rigs", function () {
         // Attempt to park the Rig with an address that doesn't own the token
         const sender = accounts[5];
         await expect(
-          rigs.connect(sender)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(sender)["unstake(uint256)"](BigNumber.from(tokenId))
         ).to.be.rejectedWith("Unauthorized");
         // Attempt to park the Rig with an address that doesn't own the token
       });
@@ -1824,14 +1822,14 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Park the Rig before training has been completed
         await expect(
-          rigs.connect(tokenOwner)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
         ).to.emit(pilots, "Parked");
         // Try to park the Rig again
         await expect(
-          rigs.connect(tokenOwner)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
         ).to.be.rejectedWith("InvalidPilotStatus");
       });
 
@@ -1848,7 +1846,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Check the Rig is in-flight, training
         // Recall that a state of `TRAINING` means that the contract is zero but pilot is set to `1`
         let pilotInfo = await rigs["pilotInfo(uint256)"](
@@ -1861,7 +1859,7 @@ describe("Rigs", function () {
         expect(pilotInfo.id).to.equal(BigNumber.from(1));
         // Park the Rig before training has been completed
         await expect(
-          rigs.connect(tokenOwner)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
         ).to.emit(pilots, "Parked");
         // Check that the index is now `0` since training was incomplete
         // Recall that a state of `UNTRAINED` means that the contract is zero and pilot is set to `0`
@@ -1874,7 +1872,7 @@ describe("Rigs", function () {
         // Start training again but also park before training completed (advance 10 blocks)
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(10),
         ]);
@@ -1887,7 +1885,7 @@ describe("Rigs", function () {
         expect(pilotInfo.id).to.equal(BigNumber.from(1));
         // Park the Rig before training has been completed
         await expect(
-          rigs.connect(tokenOwner)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
         ).to.emit(pilots, "Parked");
         // Check that the pilot is now `0` since training was incomplete
         pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
@@ -1899,7 +1897,7 @@ describe("Rigs", function () {
         // Start training again and advance 172800 blocks (30 days)
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
         ]);
@@ -1909,7 +1907,7 @@ describe("Rigs", function () {
         expect(pilotInfo.pilotable).to.equal(true);
         // Park the Rig now that training has been completed
         await expect(
-          rigs.connect(tokenOwner)["parkRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
         )
           .to.emit(pilots, "Parked")
           .withArgs(BigNumber.from(tokenId));
@@ -1934,7 +1932,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Try to transfer the Rig to `receiver`
         const receiver = accounts[5];
         await expect(
@@ -1949,7 +1947,7 @@ describe("Rigs", function () {
         // Park the Rig, and now successfully transfer
         await rigs
           .connect(tokenOwner)
-          ["parkRig(uint256)"](BigNumber.from(tokenId));
+          ["unstake(uint256)"](BigNumber.from(tokenId));
         await expect(
           rigs
             .connect(tokenOwner)
@@ -1998,7 +1996,7 @@ describe("Rigs", function () {
         // Put the Rigs in-flight
         rigs
           .connect(tokenOwner)
-          ["trainRig(uint256[])"]([
+          ["stake(uint256[])"]([
             BigNumber.from(tokenId1),
             BigNumber.from(tokenId2),
           ]);
@@ -2006,7 +2004,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["parkRig(uint256[])"]([
+            ["unstake(uint256[])"]([
               BigNumber.from(tokenId1),
               BigNumber.from(tokenId2),
             ])
@@ -2028,14 +2026,12 @@ describe("Rigs", function () {
         const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Put the Rigs in-flight
-        rigs
-          .connect(tokenOwner)
-          ["trainRig(uint256[])"]([BigNumber.from(tokenId)]);
+        rigs.connect(tokenOwner)["stake(uint256[])"]([BigNumber.from(tokenId)]);
         // Park the Rig, but pass the same Rig `tokenId` twice -- the second parking attempt will fail
         await expect(
           rigs
             .connect(tokenOwner)
-            ["parkRig(uint256[])"]([
+            ["unstake(uint256[])"]([
               BigNumber.from(tokenId),
               BigNumber.from(tokenId),
             ])
@@ -2047,12 +2043,12 @@ describe("Rigs", function () {
 
       it("Should not batch pilot Rig with empty array or exceeding max length for array", async function () {
         // Try with an empty array
-        await expect(rigs["parkRig(uint256[])"]([])).to.be.rejectedWith(
+        await expect(rigs["unstake(uint256[])"]([])).to.be.rejectedWith(
           "InvalidBatchPilotAction"
         );
         // Try with an array of tokens exceeding 255 in length (the arbitrary limit)
         const tokenIds = [...Array(256).keys()];
-        await expect(rigs["parkRig(uint256[])"](tokenIds)).to.be.rejectedWith(
+        await expect(rigs["unstake(uint256[])"](tokenIds)).to.be.rejectedWith(
           "InvalidBatchPilotAction"
         );
       });
@@ -2091,7 +2087,7 @@ describe("Rigs", function () {
         // Start training
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Check pilot is training
         pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(1);
@@ -2105,7 +2101,7 @@ describe("Rigs", function () {
         // Start training again
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -2129,7 +2125,7 @@ describe("Rigs", function () {
         // Train the Rig
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -2148,7 +2144,7 @@ describe("Rigs", function () {
         expect(pilotInfo.id).to.equal(BigNumber.from(0));
         // Train the Rig
         await expect(
-          rigs.connect(tokenOwner)["trainRig(uint256)"](BigNumber.from(tokenId))
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
         )
           .to.emit(pilots, "Training")
           .withArgs(BigNumber.from(tokenId));
@@ -2167,7 +2163,7 @@ describe("Rigs", function () {
         // Train the Rig
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+          ["stake(uint256)"](BigNumber.from(rigTokenId));
         // Advance 172800 blocks (30 days)
         await network.provider.send("hardhat_mine", [
           ethers.utils.hexValue(172800),
@@ -2184,7 +2180,7 @@ describe("Rigs", function () {
         // Pilot the Rig
         await rigs
           .connect(tokenOwner)
-          ["pilotRig(uint256,address,uint256)"](
+          ["stake(uint256,address,uint256)"](
             BigNumber.from(rigTokenId),
             fauxERC721.address,
             pilotTokenId
@@ -2205,7 +2201,7 @@ describe("Rigs", function () {
         await expect(
           await rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(rigTokenId),
               fauxERC721.address,
               pilotTokenId
@@ -2230,9 +2226,7 @@ describe("Rigs", function () {
         const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Put the Rigs in-flight
-        rigs
-          .connect(tokenOwner)
-          ["trainRig(uint256[])"]([BigNumber.from(tokenId)]);
+        rigs.connect(tokenOwner)["stake(uint256[])"]([BigNumber.from(tokenId)]);
         // Park the Rig, but pass the same Rig `tokenId` twice -- the second parking attempt will fail
         await expect(
           rigs.parkRigAsOwner([
@@ -2295,7 +2289,7 @@ describe("Rigs", function () {
         // Start training
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Check pilot is training
         pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(1);
@@ -2327,9 +2321,7 @@ describe("Rigs", function () {
         const tokenId = event.args?.tokenId;
 
         // Put the Rig in-flight
-        rigs
-          .connect(tokenOwner)
-          ["trainRig(uint256[])"]([BigNumber.from(tokenId)]);
+        rigs.connect(tokenOwner)["stake(uint256[])"]([BigNumber.from(tokenId)]);
 
         // Set admin
         const admin = accounts[5];
@@ -2378,7 +2370,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Try to `safeTransferWhileFlying` by `sender`, who is not the owner
         const sender = accounts[5];
         await expect(
@@ -2420,7 +2412,7 @@ describe("Rigs", function () {
         // Train the Rig, putting it in-flight, and advance 1 block
         await rigs
           .connect(tokenOwner)
-          ["trainRig(uint256)"](BigNumber.from(tokenId));
+          ["stake(uint256)"](BigNumber.from(tokenId));
         // Successfully use`safeTransferWhileFlying` to transfer the Rig to `receiver`
         const receiver = accounts[5];
         await expect(
@@ -2456,7 +2448,7 @@ describe("Rigs", function () {
         await expect(
           rigs
             .connect(tokenOwner)
-            ["trainRig(uint256)"](BigNumber.from(BigNumber.from(tokenId)))
+            ["stake(uint256)"](BigNumber.from(BigNumber.from(tokenId)))
         )
           .to.emit(rigs, "MetadataUpdate")
           .withArgs(BigNumber.from(tokenId));
@@ -2468,7 +2460,7 @@ describe("Rigs", function () {
         await expect(
           await rigs
             .connect(tokenOwner)
-            ["parkRig(uint256)"](BigNumber.from(tokenId))
+            ["unstake(uint256)"](BigNumber.from(tokenId))
         )
           .to.emit(rigs, "MetadataUpdate")
           .withArgs(BigNumber.from(tokenId));
@@ -2485,7 +2477,7 @@ describe("Rigs", function () {
         await expect(
           await rigs
             .connect(tokenOwner)
-            ["pilotRig(uint256,address,uint256)"](
+            ["stake(uint256,address,uint256)"](
               BigNumber.from(tokenId),
               fauxERC721.address,
               pilotTokenId
@@ -2500,8 +2492,122 @@ describe("Rigs", function () {
       });
     });
 
+    describe("token reputation", function () {
+      it("Should emit a staking event upon training", async function () {
+        // First, mint a Rig to `tokenOwner`
+        await rigs.setMintPhase(3);
+        const tokenOwner = accounts[4];
+        let tx = await rigs
+          .connect(tokenOwner)
+          ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+        let receipt = await tx.wait();
+        let [event] = receipt.events ?? [];
+        const tokenId = event.args?.tokenId;
+        // Start to train the Rig
+        tx = await rigs
+          .connect(tokenOwner)
+          ["stake(uint256)"](BigNumber.from(tokenId));
+        receipt = await tx.wait();
+        [, , event] = receipt.events ?? [];
+        // Save the block number
+        const blockNumber = tx.blockNumber;
+        // Check that `Staked` was emitted
+        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
+        expect(event.args?.owner).to.equal(tokenOwner.address);
+        expect(event.args?.block).to.equal(blockNumber);
+      });
+
+      it("Should emit an unstaking event upon parking", async function () {
+        // First, mint a Rig to `tokenOwner`
+        await rigs.setMintPhase(3);
+        const tokenOwner = accounts[4];
+        let tx = await rigs
+          .connect(tokenOwner)
+          ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+        let receipt = await tx.wait();
+        let [event] = receipt.events ?? [];
+        const tokenId = event.args?.tokenId;
+        // Train the Rig & check `MetadataUpdate` was emitted
+        // Start to train the Rig
+        tx = await rigs
+          .connect(tokenOwner)
+          ["stake(uint256)"](BigNumber.from(tokenId));
+        receipt = await tx.wait();
+        [, , event] = receipt.events ?? [];
+        // Save the block number
+        let blockNumber = tx.blockNumber;
+        // Check `Staked` was emitted
+        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
+        expect(event.args?.owner).to.equal(tokenOwner.address);
+        expect(event.args?.block).to.equal(blockNumber);
+        // Advance 172800 blocks (30 days)
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(172800),
+        ]);
+        // Park the Rig & check `Unstaked` was emitted
+        tx = await rigs
+          .connect(tokenOwner)
+          ["unstake(uint256)"](BigNumber.from(tokenId));
+        receipt = await tx.wait();
+        [, , event] = receipt.events ?? [];
+        // Save the block number
+        blockNumber = tx.blockNumber;
+        // Check that `Unstaked` was emitted
+        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
+        expect(event.args?.owner).to.equal(tokenOwner.address);
+        expect(event.args?.block).to.equal(blockNumber);
+      });
+
+      it("Should emit a staking event upon piloting", async function () {
+        // First, mint a Rig to `tokenOwner`
+        await rigs.setMintPhase(3);
+        const tokenOwner = accounts[4];
+        let tx = await rigs
+          .connect(tokenOwner)
+          ["mint(uint256)"](1, { value: getCost(1, 0.05) });
+        let receipt = await tx.wait();
+        let [event] = receipt.events ?? [];
+        const tokenId = event.args?.tokenId;
+        // Start to train the Rig
+        tx = await rigs
+          .connect(tokenOwner)
+          ["stake(uint256)"](BigNumber.from(tokenId));
+        receipt = await tx.wait();
+        // Advance 172800 blocks (30 days)
+        await network.provider.send("hardhat_mine", [
+          ethers.utils.hexValue(172800),
+        ]);
+        // Deploy a faux ERC-721 token
+        const FauxERC721Factory = await ethers.getContractFactory(
+          "TestERC721Enumerable"
+        );
+        const fauxERC721 = await (await FauxERC721Factory.deploy()).deployed();
+        tx = await fauxERC721.connect(tokenOwner).mint();
+        receipt = await tx.wait();
+        [event] = receipt.events ?? [];
+        const pilotTokenId = event.args?.tokenId;
+        // Pilot the Rig & check `Staked` was emitted
+        tx = await rigs
+          .connect(tokenOwner)
+          ["stake(uint256,address,uint256)"](
+            BigNumber.from(tokenId),
+            fauxERC721.address,
+            pilotTokenId
+          );
+        receipt = await tx.wait();
+        [, , , event] = receipt.events ?? [];
+        console.log(receipt.events![3]);
+        // Save the block number
+        const blockNumber = tx.blockNumber;
+        // Check that `Unstaked` was emitted
+        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
+        expect(event.args?.owner).to.equal(tokenOwner.address);
+        expect(event.args?.block).to.equal(blockNumber);
+      });
+    });
+
     describe("delegation", function () {
-      describe("trainRig", function () {
+      describe("stake", function () {
         it("Should train Rig if msg.sender is registered delegate for token.owner", async function () {
           // First, mint a Rig to `tokenOwner`
           await rigs.setMintPhase(3);
@@ -2524,7 +2630,7 @@ describe("Rigs", function () {
 
           // Train the Rig
           await expect(
-            rigs.connect(delegate)["trainRig(uint256)"](BigNumber.from(tokenId))
+            rigs.connect(delegate)["stake(uint256)"](BigNumber.from(tokenId))
           )
             .to.emit(pilots, "Training")
             .withArgs(BigNumber.from(tokenId));
@@ -2545,7 +2651,7 @@ describe("Rigs", function () {
           // Train the Rig, putting it in-flight, and advance 1 block
           await rigs
             .connect(rigTokenOwner)
-            ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+            ["stake(uint256)"](BigNumber.from(rigTokenId));
           // Advance 172800 blocks (30 days)
           await network.provider.send("hardhat_mine", [
             ethers.utils.hexValue(172800),
@@ -2553,7 +2659,7 @@ describe("Rigs", function () {
           // Park the Rig now that training has been completed
           await rigs
             .connect(rigTokenOwner)
-            ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+            ["unstake(uint256)"](BigNumber.from(rigTokenId));
           // Deploy a faux ERC-721 token but mint to an address *not* `rigTokenOwner`
           const FauxERC721Factory = await ethers.getContractFactory(
             "TestERC721Enumerable"
@@ -2579,7 +2685,7 @@ describe("Rigs", function () {
           await expect(
             await rigs
               .connect(delegate)
-              ["pilotRig(uint256,address,uint256)"](
+              ["stake(uint256,address,uint256)"](
                 BigNumber.from(rigTokenId),
                 fauxERC721.address,
                 pilotTokenIdRigOwner
@@ -2606,7 +2712,7 @@ describe("Rigs", function () {
           // Train the Rig, putting it in-flight, and advance 1 block
           await rigs
             .connect(rigTokenOwner)
-            ["trainRig(uint256)"](BigNumber.from(rigTokenId));
+            ["stake(uint256)"](BigNumber.from(rigTokenId));
           // Advance 172800 blocks (30 days)
           await network.provider.send("hardhat_mine", [
             ethers.utils.hexValue(172800),
@@ -2614,7 +2720,7 @@ describe("Rigs", function () {
           // Park the Rig now that training has been completed
           await rigs
             .connect(rigTokenOwner)
-            ["parkRig(uint256)"](BigNumber.from(rigTokenId));
+            ["unstake(uint256)"](BigNumber.from(rigTokenId));
 
           // Setup delegation
           const delegate = accounts[5];
@@ -2628,7 +2734,7 @@ describe("Rigs", function () {
           await expect(
             await rigs
               .connect(delegate)
-              ["pilotRig(uint256,address,uint256)"](
+              ["stake(uint256,address,uint256)"](
                 BigNumber.from(rigTokenId),
                 ethers.constants.AddressZero,
                 BigNumber.from(1337)
@@ -2657,9 +2763,7 @@ describe("Rigs", function () {
 
           // Train the Rig
           await expect(
-            rigs
-              .connect(tokenOwner)
-              ["trainRig(uint256)"](BigNumber.from(tokenId))
+            rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
           )
             .to.emit(pilots, "Training")
             .withArgs(BigNumber.from(tokenId));
@@ -2674,7 +2778,7 @@ describe("Rigs", function () {
           );
 
           await expect(
-            rigs.connect(delegate)["parkRig(uint256)"](BigNumber.from(tokenId))
+            rigs.connect(delegate)["unstake(uint256)"](BigNumber.from(tokenId))
           )
             .to.emit(pilots, "Parked")
             .withArgs(BigNumber.from(tokenId));

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -691,6 +691,8 @@ describe("Rigs", function () {
       expect(await rigs.supportsInterface("0x2a55205a")).to.equal(true);
       // ERC165 interface ID for ERC4906
       expect(await rigs.supportsInterface("0x49064906")).to.equal(true);
+      // ERC165 interface ID for ITokenReputation
+      expect(await rigs.supportsInterface("0x88832242")).to.equal(true);
     });
   });
 
@@ -2300,17 +2302,11 @@ describe("Rigs", function () {
         let [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Start to stake the Rig
-        tx = await rigs
-          .connect(tokenOwner)
-          ["stake(uint256)"](BigNumber.from(tokenId));
-        receipt = await tx.wait();
-        [, , event] = receipt.events ?? [];
-        // Save the block number
-        const blockNumber = tx.blockNumber;
-        // Check that `Stake` was emitted
-        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
-        expect(event.args?.owner).to.equal(tokenOwner.address);
-        expect(event.args?.block).to.equal(blockNumber);
+        await expect(
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
+        )
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
 
       it("Should emit an Unstaked event upon unstaking", async function () {
@@ -2325,29 +2321,17 @@ describe("Rigs", function () {
         const tokenId = event.args?.tokenId;
         // Stake the Rig & check `MetadataUpdate` was emitted
         // Start to pilot the Rig
-        tx = await rigs
-          .connect(tokenOwner)
-          ["stake(uint256)"](BigNumber.from(tokenId));
-        receipt = await tx.wait();
-        [, , event] = receipt.events ?? [];
-        // Save the block number
-        let blockNumber = tx.blockNumber;
-        // Check `Stake` was emitted
-        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
-        expect(event.args?.owner).to.equal(tokenOwner.address);
-        expect(event.args?.block).to.equal(blockNumber);
+        await expect(
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
+        )
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
         // Park the Rig & check `Unstake` was emitted
-        tx = await rigs
-          .connect(tokenOwner)
-          ["unstake(uint256)"](BigNumber.from(tokenId));
-        receipt = await tx.wait();
-        [, , event] = receipt.events ?? [];
-        // Save the block number
-        blockNumber = tx.blockNumber;
-        // Check that `Unstake` was emitted
-        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
-        expect(event.args?.owner).to.equal(tokenOwner.address);
-        expect(event.args?.block).to.equal(blockNumber);
+        await expect(
+          rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
+        )
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
 
       it("Should emit a Staked event upon staking with pilot", async function () {
@@ -2368,23 +2352,12 @@ describe("Rigs", function () {
         tx = await fauxERC721.connect(tokenOwner).mint();
         receipt = await tx.wait();
         [event] = receipt.events ?? [];
-        const pilotTokenId = event.args?.tokenId;
         // Pilot the Rig & check `Stake` was emitted
-        tx = await rigs
-          .connect(tokenOwner)
-          ["stake(uint256,address,uint256)"](
-            BigNumber.from(tokenId),
-            fauxERC721.address,
-            pilotTokenId
-          );
-        receipt = await tx.wait();
-        [, , event] = receipt.events ?? [];
-        // Save the block number
-        const blockNumber = tx.blockNumber;
-        // Check that `Unstake` was emitted
-        expect(event.args?.tokenId).to.equal(BigNumber.from(tokenId));
-        expect(event.args?.owner).to.equal(tokenOwner.address);
-        expect(event.args?.block).to.equal(blockNumber);
+        await expect(
+          rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
+        )
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
     });
 

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -853,8 +853,8 @@ describe("Rigs", function () {
         await expect(
           rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(BigNumber.from(tokenId), ethers.constants.AddressZero, 1);
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
 
       it("Should not stake Rig if it has already left the garage", async function () {
@@ -902,10 +902,10 @@ describe("Rigs", function () {
               BigNumber.from(tokenId2),
             ])
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(BigNumber.from(tokenId1), ethers.constants.AddressZero, 1)
-          .to.emit(pilots, "Piloted")
-          .withArgs(BigNumber.from(tokenId2), ethers.constants.AddressZero, 1);
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId1), tokenOwner.address)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId2), tokenOwner.address);
       });
 
       it("Should not batch stake a duplicate Rig token value", async function () {
@@ -927,8 +927,8 @@ describe("Rigs", function () {
               BigNumber.from(tokenId),
             ])
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(BigNumber.from(tokenId), ethers.constants.AddressZero, 1)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address)
           .to.be.rejectedWith("InvalidPilotStatus");
       });
 
@@ -1124,12 +1124,8 @@ describe("Rigs", function () {
               pilotTokenIdRigOwner
             )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenIdRigOwner)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId), rigTokenOwner.address);
         // Try to stake the Rig again, even though it's already in-flight
         await expect(
           rigs
@@ -1170,12 +1166,8 @@ describe("Rigs", function () {
             pilotTokenId
           );
         await expect(tx)
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId), tokenOwner.address);
         let pilotReceipt = await tx.wait();
         let blockNumber = tx.blockNumber;
         // Check the pilot info
@@ -1209,12 +1201,8 @@ describe("Rigs", function () {
             pilotTokenId
           );
         await expect(tx)
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId), tokenOwner.address);
         pilotReceipt = await tx.wait();
         blockNumber = pilotReceipt.blockNumber;
         // Check the pilot info
@@ -1246,12 +1234,8 @@ describe("Rigs", function () {
             pilotTokenId
           );
         await expect(tx)
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId),
-            fauxTwoERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId), tokenOwner.address);
         pilotReceipt = await tx.wait();
         blockNumber = pilotReceipt.blockNumber;
         // Check the pilot info
@@ -1321,12 +1305,8 @@ describe("Rigs", function () {
             BigNumber.from(2) // Pilot ID value doesn't matter
           )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(tokenId),
-            ethers.constants.AddressZero,
-            BigNumber.from(1) // Pilot ID always `1` for stock
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), rigTokenOwner.address);
       });
 
       it("Should not allow the same custom pilot to operate multiple Rigs", async function () {
@@ -1387,17 +1367,11 @@ describe("Rigs", function () {
               pilotTokenId
             )
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(rigTokenId1))
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId2),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId2), tokenOwner.address);
       });
 
-      it("Should not batch pilot Rigs for empty, unequal length, or max length for arrays", async function () {
+      it("Should not batch stake Rigs for empty, unequal length, or max length for arrays", async function () {
         // Try to send empty arrays
         await expect(
           rigs["stake(uint256[],address[],uint256[])"]([], [], [])
@@ -1453,7 +1427,7 @@ describe("Rigs", function () {
         ).to.be.rejectedWith("InvalidBatchPilotAction");
       });
 
-      it("Should not allow batch piloting with the same pilot for different Rigs", async function () {
+      it("Should not allow batch staking with the same pilot for different Rigs", async function () {
         // First, mint two Rigs to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -1489,20 +1463,10 @@ describe("Rigs", function () {
               [pilotTokenId, pilotTokenId]
             )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId1),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(rigTokenId1))
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId2),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId1), tokenOwner.address)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId2), tokenOwner.address);
         // Check the pilot info for the first Rig
         // It should be parked; its latest pilot should still be accessible
         let pilotInfo = await rigs["pilotInfo(uint256)"](
@@ -1537,20 +1501,10 @@ describe("Rigs", function () {
               [pilotTokenId, pilotTokenId]
             )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId1),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(rigTokenId1))
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId2),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId1), tokenOwner.address)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId2), tokenOwner.address);
         // Check the pilot info for the first Rig -- it should be parked; it's latest pilot should still be accessible
         pilotInfo = await rigs["pilotInfo(uint256)"](
           BigNumber.from(rigTokenId1)
@@ -1621,24 +1575,12 @@ describe("Rigs", function () {
               [pilotTokenId, 1, 1]
             )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId1),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId2),
-            ethers.constants.AddressZero, // Stock pilot contract is `0x0`
-            BigNumber.from(1) // A stock pilot is always `1`
-          )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId3),
-            ethers.constants.AddressZero,
-            BigNumber.from(1)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId1), tokenOwner.address)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId2), tokenOwner.address)
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId3), tokenOwner.address);
         // Check the pilot info for the first Rig
         let pilotInfo = await rigs["pilotInfo(uint256)"](
           BigNumber.from(rigTokenId1)
@@ -1725,7 +1667,7 @@ describe("Rigs", function () {
         // Unstake the Rig
         await expect(
           rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
-        ).to.emit(pilots, "Parked");
+        ).to.emit(rigs, "Unstake");
         // Try to park the Rig again
         await expect(
           rigs.connect(tokenOwner)["unstake(uint256)"](BigNumber.from(tokenId))
@@ -1822,13 +1764,13 @@ describe("Rigs", function () {
               BigNumber.from(tokenId2),
             ])
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId1))
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId2));
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId1), tokenOwner.address)
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId2), tokenOwner.address);
       });
 
-      it("Should not batch park a duplicate Rig token value", async function () {
+      it("Should not batch unstake a duplicate Rig token value", async function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -1850,12 +1792,12 @@ describe("Rigs", function () {
               BigNumber.from(tokenId),
             ])
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId))
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address)
           .to.be.rejectedWith("InvalidPilotStatus");
       });
 
-      it("Should not batch pilot Rig with empty array or exceeding max length for array", async function () {
+      it("Should not batch stake Rig with empty array or exceeding max length for array", async function () {
         // Try with an empty array
         await expect(rigs["unstake(uint256[])"]([])).to.be.rejectedWith(
           "InvalidBatchPilotAction"
@@ -1869,7 +1811,7 @@ describe("Rigs", function () {
     });
 
     describe("unstakeRigAsOwner", function () {
-      it("Should not park Rig as owner for non-existent token", async function () {
+      it("Should not unstake Rig as owner for non-existent token", async function () {
         await expect(
           rigs.unstakeAsOwner([BigNumber.from(0)])
         ).to.be.rejectedWith("OwnerQueryForNonexistentToken");
@@ -1883,7 +1825,7 @@ describe("Rigs", function () {
         );
       });
 
-      it("Should allow contract owner to park any Rig", async function () {
+      it("Should allow contract owner to unstake any Rig", async function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -1907,8 +1849,8 @@ describe("Rigs", function () {
         expect(pilotInfo.status).to.equal(1);
         // Park the Rig as the contract owner
         await expect(rigs.unstakeAsOwner([BigNumber.from(tokenId)]))
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId));
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
         // Check pilot is back to untrained
         pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(0);
@@ -1922,11 +1864,11 @@ describe("Rigs", function () {
         ]);
         // Park the Rig as the contract owner
         await expect(rigs.unstakeAsOwner([BigNumber.from(tokenId)]))
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId));
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
 
-      it("Should allow stock piloting after being force parked", async function () {
+      it("Should allow stock staking after being force parked", async function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -1956,8 +1898,8 @@ describe("Rigs", function () {
         await expect(
           rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(BigNumber.from(tokenId), ethers.constants.AddressZero, 1);
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
       });
 
       it("Should allow custom piloting after previously force parked", async function () {
@@ -2009,15 +1951,11 @@ describe("Rigs", function () {
               pilotTokenId
             )
         )
-          .to.emit(pilots, "Piloted")
-          .withArgs(
-            BigNumber.from(rigTokenId),
-            fauxERC721.address,
-            BigNumber.from(pilotTokenId)
-          );
+          .to.emit(rigs, "Stake")
+          .withArgs(BigNumber.from(rigTokenId), tokenOwner.address);
       });
 
-      it("Should not batch park a duplicate Rig token value", async function () {
+      it("Should not batch unstake a duplicate Rig token value", async function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -2036,12 +1974,12 @@ describe("Rigs", function () {
             BigNumber.from(tokenId),
           ])
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId))
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address)
           .to.be.rejectedWith("InvalidPilotStatus");
       });
 
-      it("Should not batch pilot Rig with empty array or exceeding max length for array", async function () {
+      it("Should not batch stake Rig with empty array or exceeding max length for array", async function () {
         // Try with an empty array
         await expect(rigs.unstakeAsOwner([])).to.be.rejectedWith(
           "InvalidBatchPilotAction"
@@ -2055,7 +1993,7 @@ describe("Rigs", function () {
     });
 
     describe("unstakeAsAdmin", function () {
-      it("Should not park Rig as admin for non-existent token", async function () {
+      it("Should not unstake Rig as admin for non-existent token", async function () {
         const admin = accounts[2];
         await rigs.setAdmin(admin.address);
 
@@ -2104,14 +2042,14 @@ describe("Rigs", function () {
         await expect(
           rigs.connect(admin).unstakeAsAdmin([BigNumber.from(tokenId)])
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId));
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address);
         // Check pilot is back to untrained
         pilotInfo = await rigs["pilotInfo(uint256)"](BigNumber.from(tokenId));
         expect(pilotInfo.status).to.equal(0);
       });
 
-      it("Should not batch park a duplicate Rig token value", async function () {
+      it("Should not batch unstake a duplicate Rig token value", async function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
@@ -2135,12 +2073,12 @@ describe("Rigs", function () {
             .connect(admin)
             .unstakeAsAdmin([BigNumber.from(tokenId), BigNumber.from(tokenId)])
         )
-          .to.emit(pilots, "Parked")
-          .withArgs(BigNumber.from(tokenId))
+          .to.emit(rigs, "Unstake")
+          .withArgs(BigNumber.from(tokenId), tokenOwner.address)
           .to.be.rejectedWith("InvalidPilotStatus");
       });
 
-      it("Should not batch pilot Rig with empty array or exceeding max length for array", async function () {
+      it("Should not batch stake Rig with empty array or exceeding max length for array", async function () {
         const admin = accounts[5];
         await rigs.setAdmin(admin.address);
 
@@ -2363,7 +2301,7 @@ describe("Rigs", function () {
 
     describe("delegation", function () {
       describe("stake (stock pilot)", function () {
-        it("Should train Rig if msg.sender is registered delegate for token.owner", async function () {
+        it("Should stake Rig if msg.sender is registered delegate for token.owner", async function () {
           // First, mint a Rig to `tokenOwner`
           await rigs.setMintPhase(3);
           const tokenOwner = accounts[4];
@@ -2387,8 +2325,8 @@ describe("Rigs", function () {
           await expect(
             rigs.connect(delegate)["stake(uint256)"](BigNumber.from(tokenId))
           )
-            .to.emit(pilots, "Piloted")
-            .withArgs(BigNumber.from(tokenId), ethers.constants.AddressZero, 1);
+            .to.emit(rigs, "Stake")
+            .withArgs(BigNumber.from(tokenId), delegate.address);
         });
       });
 
@@ -2442,15 +2380,11 @@ describe("Rigs", function () {
                 pilotTokenIdRigOwner
               )
           )
-            .to.emit(pilots, "Piloted")
-            .withArgs(
-              BigNumber.from(rigTokenId),
-              fauxERC721.address,
-              BigNumber.from(pilotTokenIdRigOwner)
-            );
+            .to.emit(rigs, "Stake")
+            .withArgs(BigNumber.from(rigTokenId), delegate.address);
         });
 
-        it("Should pilot with the stock pilot rig if msg.sender is registered delegate for token.owner", async function () {
+        it("Should stake with the stock pilot rig if msg.sender is registered delegate for token.owner", async function () {
           // First, mint a Rig to `rigTokenOwner`
           await rigs.setMintPhase(3);
           const rigTokenOwner = accounts[4];
@@ -2487,17 +2421,13 @@ describe("Rigs", function () {
                 BigNumber.from(1337)
               )
           )
-            .to.emit(pilots, "Piloted")
-            .withArgs(
-              BigNumber.from(rigTokenId),
-              ethers.constants.AddressZero,
-              BigNumber.from(1) // Pilot ID always `1` for stock
-            );
+            .to.emit(rigs, "Stake")
+            .withArgs(BigNumber.from(rigTokenId), delegate.address);
         });
       });
 
       describe("unstake", function () {
-        it("Should park Rig if msg.sender is registered delegate for token.owner", async function () {
+        it("Should unstake Rig if msg.sender is registered delegate for token.owner", async function () {
           // First, mint a Rig to `tokenOwner`
           await rigs.setMintPhase(3);
           const tokenOwner = accounts[4];
@@ -2512,8 +2442,8 @@ describe("Rigs", function () {
           await expect(
             rigs.connect(tokenOwner)["stake(uint256)"](BigNumber.from(tokenId))
           )
-            .to.emit(pilots, "Piloted")
-            .withArgs(BigNumber.from(tokenId), ethers.constants.AddressZero, 1);
+            .to.emit(rigs, "Stake")
+            .withArgs(BigNumber.from(tokenId), tokenOwner.address);
 
           // Setup delegation
           const delegate = accounts[5];
@@ -2527,8 +2457,8 @@ describe("Rigs", function () {
           await expect(
             rigs.connect(delegate)["unstake(uint256)"](BigNumber.from(tokenId))
           )
-            .to.emit(pilots, "Parked")
-            .withArgs(BigNumber.from(tokenId));
+            .to.emit(rigs, "Unstake")
+            .withArgs(BigNumber.from(tokenId), delegate.address);
         });
       });
     });

--- a/ethereum/test/TablelandRigs.ts
+++ b/ethereum/test/TablelandRigs.ts
@@ -2295,11 +2295,11 @@ describe("Rigs", function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
-        let tx = await rigs
+        const tx = await rigs
           .connect(tokenOwner)
           ["mint(uint256)"](1, { value: getCost(1, 0.05) });
-        let receipt = await tx.wait();
-        let [event] = receipt.events ?? [];
+        const receipt = await tx.wait();
+        const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Start to stake the Rig
         await expect(
@@ -2313,11 +2313,11 @@ describe("Rigs", function () {
         // First, mint a Rig to `tokenOwner`
         await rigs.setMintPhase(3);
         const tokenOwner = accounts[4];
-        let tx = await rigs
+        const tx = await rigs
           .connect(tokenOwner)
           ["mint(uint256)"](1, { value: getCost(1, 0.05) });
-        let receipt = await tx.wait();
-        let [event] = receipt.events ?? [];
+        const receipt = await tx.wait();
+        const [event] = receipt.events ?? [];
         const tokenId = event.args?.tokenId;
         // Stake the Rig & check `MetadataUpdate` was emitted
         // Start to pilot the Rig

--- a/ethereum/test/proxy/TablelandRigPilotsProxy.ts
+++ b/ethereum/test/proxy/TablelandRigPilotsProxy.ts
@@ -1,4 +1,6 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import "@nomicfoundation/hardhat-toolbox";
+import "@openzeppelin/hardhat-upgrades";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { ethers, upgrades } from "hardhat";

--- a/ethereum/test/proxy/TablelandRigsProxy.ts
+++ b/ethereum/test/proxy/TablelandRigsProxy.ts
@@ -1,6 +1,9 @@
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
+import "@nomiclabs/hardhat-ethers";
+import "@nomicfoundation/hardhat-toolbox";
+import "@openzeppelin/hardhat-upgrades";
 import { ethers, upgrades } from "hardhat";
 import { utils, BigNumber, Contract, ContractFactory } from "ethers";
 import { buildTree } from "../../helpers/allowlist";

--- a/research/eip-draft_token_reputation.md
+++ b/research/eip-draft_token_reputation.md
@@ -1,0 +1,323 @@
+---
+title: Token-based reputation
+description: A minimal ERC-721 extension for token-based reputation.
+author: Daniel Buchholz (@dtbuchholz) <dan@tableland.xyz>, Sander Pick (@sanderpick) <sander@tableland.xyz>
+discussions-to: https://github.com/ethereum/eips/issues/<EIP_NUMBER> # TODO: Update
+status: Draft
+type: Standards Track
+category: ERC
+created: <yyyy-mm-dd> # TODO: Update
+requires: 165, 721
+---
+
+## Abstract
+
+This token-based reputation standard for Non-Fungible Tokens (NFTs) extends [ERC-721](https://eips.ethereum.org/EIPS/eip-721) by defining a standardized set of staking/unstaking actions and metadata attributes that correspond to reputation earned by the token owner, which also enable/disable trading these tokens on marketplaces.
+
+## Motivation
+
+NFTs are a conduit for holder-initiated actions that attribute to the token owner's reputation. Namely, this proposal introduces two primary components to help maintain a record of reputation earned on the blockchain:
+
+- The concept of "soft" staking and unstaking wherein a token cannot be sold on marketplaces while staked, and the token ownership remains unchanged wherein the holder's account maintains ownership.
+- Dynamic metadata changes, signaled by `Stake` and `Unstake` events, are materialized in the metadata by the implementer (OPTIONAL) using the data availability ("DA") layer.
+
+For example, a token owner may stake or unstake their token to signal their support/disapproval for a project. Currently, there does not exist a lightweight standard for implementing these signals, which leads to disparate implementations and an overall lack of interoperable reputation across different communities. This proposal aims to standardize a set of staking/unstaking events, methods, and OPTIONAL dynamic metadata attributes that correspond to reputation earned by the token owner.
+
+Note there are two existing EIPs that have somewhat of a similar approach but come with flaws from the perspective of generalizing an interface for the broadest set of use cases:
+
+- [EIP-5192](https://eips.ethereum.org/EIPS/eip-5192): Designed for non-transferrable "soulbound" tokens ("SBT"), EIP-5192 has a few features that do not align with the token reputation requirements:
+  - Lacks a way to initiate _both_ staking and unstaking actions through standardized method calls—it only provides a `locked` getter method, which is unneeded for many use cases.
+  - Lack of indexed event parameters needed for the metadata, such as the caller's address or block number.
+  - Potentially misleading nomenclature if used for non-SBT use cases, whereas "staking" is more applicable to not only reputation-based scenarios but is also widely adopted elsewhere.
+- [EIP-5753](https://eips.ethereum.org/EIPS/eip-5753): Although EIP-5753 is currently a draft and yet to be accepted, it (essentially) changes EIP-5192 with the following:
+  - Adds `lock` and `unlock` methods, which behave similar to the token reputation proposal's `stake` and `unstake` methods; however, `unlock` lacks the required method caller information, as do the `Lock` and `Unlock` events.
+  - Changes the EIP-5192 `locked` getter to a function named `getLocked` that returns an address instead of boolean; but, getters SHOULD NOT be required for a minimal interface as this assumes contract storage is used to track reputation, which is not always the case (e.g., off-chain metadata / DA based reputation tracking).
+
+These two EIPs also lack the emittance of a `block.number` within their events. This is a key component for enabling reputation in metadata, which is a primary yet OPTIONAL feature of this proposal. For reputation to dynamically change within the metadata, there MUST be block information in the event emittance for off-chain indexing as this is needed to materialize any metadata updates with block-related information. In other words, reputation is most often tracked with a start and end block number that bound the staking/unstaking activities.
+
+For reference, [OpenSea](https://docs.opensea.io/docs/metadata-standards#disable-trading-for-staked-or-locked-tokens) leverages both of the events noted in EIP-5192 and EIP-5753 to disable trading for staked/locked tokens. There are other accepted events by OpenSea, including the `Stake` and `Unstake` events outlined in this proposal, which _do not_ have an EIP associated with them. Although it is not necessarily the primary motivation of this token reputation EIP, it's been noted to demonstrate how marketplaces are using this EIP's event definitions today. In other words, it is true that the events outlined in this proposal **will disable/enable trading a token on marketplaces**; this proposal _already_ has real-world usage.
+
+## Specification
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
+
+### Stake and Unstake Functions
+
+An owner SHALL be able to "soft" stake and unstake their token; staking and unstaking a token SHOULD NOT require a change to the ownership of the token itself but simply emit events that signal the on-chain action taken. Staking a token with `function stake(...)` signals that the owner is staking their token to accrue reputation, such as earning block-based rewards, while the token cannot be sold; reputation SHOULD be earned for good behavior during this token state. Unstaking a token with `function unstake(...)` signals that the owner no longer wishes to stake the token and is available to be sold; reputation SHOULD NOT be earned while in an unstaked state.
+
+These functions emit `Staked` and `Unstaked` events, respectively, to signal a change in state of the token. This allows for off-chain marketplaces to change listing behavior as well as the token's metadata to be dynamically changed; the metadata SHOULD be changed by the implementer upon event emittance, but is is entirely OPTIONAL. Namely, there is no required contract storage for token reputation, so the events and metadata are what actually SHOULD store reputation, as provided by the DA layer. The implementor can choose to store reputation in contract storage, if desired. It is a key design component as this keeps the interface as lightweight as possible while also ensuring there is not a lossy process for determining a token's reputation fully off-chain.
+
+**Every contract compliant with this EIP MUST implement the `ERC721` interface.**
+
+```solidity
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+/**
+ * @title A minimal ERC-721 extension for token-based reputation.
+ */
+interface ITokenReputation {
+    /**
+     * @notice Emitted when token staking is initiated.
+     * @param tokenId Identifier for the token being staked.
+     * @param owner The token owner who wants to stake the token.
+     * @param block The block number at the time of staking.
+     */
+    event Stake(
+        uint256 indexed tokenId,
+        address indexed owner,
+        uint256 indexed block
+    );
+
+    /**
+     * @notice Emitted when token unstaking is initiated.
+     * @param tokenId Identifier for the token being unstaked.
+     * @param owner The token owner who wants to unstake the token.
+     * @param block The block number at the time of unstaking.
+     */
+    event Unstake(
+        uint256 indexed tokenId,
+        address indexed owner,
+        uint256 indexed block
+    );
+
+    /**
+     * @notice Stake the token, disabling marketplace transfers.
+     * @param tokenId The unique token identifier.
+     */
+    function stake(uint256 tokenId) external;
+
+    /**
+     * @notice Unstake the token, enabling marketplace transfers.
+     * @param tokenId The unique token identifier.
+     */
+    function unstake(uint256 tokenId) external;
+}
+```
+
+Every contract compliant with this token reputation EIP MusT also use the feature detection functionality of EIP-165 such that calling `function supportsInterface(bytes4 interfaceID) external view returns (bool)` with `interfaceID` of `0x88832242` MUST return `true`. As EIP-165 and EIP-721 are also required, an example is provided below:
+
+```solidity
+function supportsInterface(bytes4 interfaceID) external view returns (bool) {
+    return
+        interfaceID == 0x01ffc9a7 || // ERC-165 support
+        interfaceID == 0x80ac58cd || // ERC-721 support
+        interfaceID == 0x88832242;   // Token reputation support
+}
+```
+
+### Disable or Enable Trading
+
+The `Stake` and `Unstake` events SHOULD be used by off-chain marketplaces to disable/enable trading of a token, which is already used by OpenSea today. Upon a `Stake` event, the `tokenId` can be used to disable trading the specified token. With an `Unstake` emittance, trading is then enabled. By default, an NFT that has not been staked yet will have trading enabled.
+
+### Metadata Definition
+
+The RECOMMENDED metadata format for reputation is defined below. Implementing this metadata is OPTIONAL and up to the implementor, and since events signal staking and unstaking actions, the metadata SHOULD dynamically update upon these events being emitted. For example, a common NFT metadata standard is the following, which would place the `Reputation` score within the `attributes` array:
+
+```json
+{
+  // ...
+  "attributes": [
+    {
+      "display_type": "number",
+      "trait_type": "Reputation",
+      "value": 123 // Calculated reputation score, e.g., difference between stake/unstake block numbers
+    }
+    // ...
+  ]
+}
+```
+
+A benefit of the `Stake` and `Unstake` events is that they include the `address` parameter along with the `tokenId` and `block` number. This is a unique feature in that the token can act as a proxy to reputation earned. That is, from a metadata perspective, the implementor could choose to track _both_ the reputation earned that's tied to the specific token ID and/or the address that owned the token. Since there are no default limitations on selling a reputation token while it is **not staked**, one could create a transferrable reputation system or choose to block transferability altogether, if desired. Again, this proposal tries to enable the maximum amount of flexibility.
+
+## Rationale
+
+The approach outlined in this EIP was designed to be as lightweight as possible and only stakes or unstakes a token, emits an event to disable/enable trading, and also allow for recreating token state through the DA layer. It is a generalized implementation and leaves reputation calculation up to the implementor but provides enough context to do so through the defined events.
+
+## Backwards Compatibility
+
+This standard is compatible with [ERC-721](https://eips.ethereum.org/EIPS/eip-721).
+
+## Reference Implementation
+
+Provided is a simple example how token reputation might be implemented with a very minimal `stake()` and `unstake()` implementation that simply emits a `Stake` or `Unstake` event after a token ownership check:
+
+```solidity
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "./ITokenReputation.sol";
+
+contract TokenReputation is ERC721, ITokenReputation {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIdCounter;
+
+    constructor() ERC721("Tableland", "TBL") {}
+
+    function _baseURI() internal pure override returns (string memory) {
+        return "https://tableland.xyz/";
+    }
+
+    function mint() external payable {
+        uint256 tokenId = _tokenIdCounter.current();
+        _tokenIdCounter.increment();
+        _safeMint(_msgSender(), tokenId);
+    }
+
+    function stake(uint256 tokenId) external {
+        address tokenOwner = _ownerOf(tokenId);
+        require(_msgSender() == tokenOwner, "UNAUTHORIZED"); // Only token owner can stake
+        emit Stake(tokenId, tokenOwner, block.number);
+    }
+
+    function unstake(uint256 tokenId) external {
+        address tokenOwner = _ownerOf(tokenId);
+        require(_msgSender() == tokenOwner, "UNAUTHORIZED"); // Only token owner can unstake
+        emit Unstake(tokenId, tokenOwner, block.number);
+    }
+
+    function supportsInterface(bytes4 interfaceID) public view override(ERC721) returns (bool) {
+        return
+            super.supportsInterface(interfaceID) || // Both ERC-165 & ERC-721 support
+            interfaceID == 0x88832242; // Token reputation support
+    }
+}
+```
+
+Upon `staking()` and `unstaking()`, the metadata can materialize what is described in the event and update the reputation accordingly. Perhaps the owner successfully staked and unstaked their token, and during this period, there were `500` blocks that passed. Upon additional staking/unstaking events, this score SHOULD be updated—e.g., maybe the next staking session is `1000` blocks, so the `value` below would be updated to `1500`:
+
+```json
+{
+  "attributes": [
+    {
+      "display_type": "number",
+      "trait_type": "Reputation",
+      "value": 500
+    }
+  ]
+}
+```
+
+A more complex use case could be a reputation-based application that uses token reputation as a way to define proposal voting and weights that correspond to each token's reputation. Here, the contract implements more specific off-chain functionality for updating the reputation score. Namely, the reputation metadata is materialized off-chain and dynamically updated upon new `Stake` and `Unstake` events, such with IPFS or an SQL database that stores the metadata:
+
+```solidity
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.10 <0.9.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import "@openzeppelin/contracts/utils/Counters.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "@tableland/evm/contracts/utils/SQLHelpers.sol";
+import "@tableland/evm/contracts/utils/TablelandDeployments.sol";
+import "./ITokenReputation.sol";
+
+contract TokenReputation is ERC721, ITokenReputation {
+    using Counters for Counters.Counter;
+    Counters.Counter private _tokenIdCounter;
+
+    uint256 private _tokenRepTableId; // Some reference used off-chain to store reputation data
+    string private constant _REPUTATION_PREFIX = "token_rep"; // Used off-chain but stored for interoperability purposes
+
+    constructor() ERC721("Tableland", "TBL") {
+        _tokenRepTableId = TablelandDeployments.get().create(
+            address(this),
+            SQLHelpers.toCreateFromSchema( // Some off-chain SQL database table schema
+                "id INTEGER PRIMARY KEY," // Track a staking session ID
+                "token_id INTEGER NOT NULL," // The specific token ID
+                "owner text NOT NULL," // The address that owns the token at that point in time
+                "start_time INTEGER NOT NULL," // Starting block for staking activity via `stake()`
+                "end_time INTEGER", // Ending block for staking activity via `unstake()`
+                _REPUTATION_PREFIX // Some off-chain SQL database table name
+            )
+        );
+    }
+
+    function _baseURI() internal view override returns (string memory) {
+        return string.concat(
+            "https://tableland.network/api/v1/query?unwrap=true&extract=true&statement=select%20json_object(%27attributes%27,json_array(json_object(%27display_type%27,%27number%27,%27trait_type%27,%27Reputation%27,%27value%27,end_time-start_time)))%20from%20",
+            SQLHelpers.toNameFromId(_REPUTATION_PREFIX, _tokenRepTableId),
+            "%20where%20token_id%20%3D%20"
+        );
+    }
+
+    function mint() external payable {
+        uint256 tokenId = _tokenIdCounter.current();
+        _tokenIdCounter.increment();
+        _safeMint(_msgSender(), tokenId);
+    }
+
+    function stake(uint256 tokenId) external {
+        address tokenOwner = _ownerOf(tokenId);
+        require(_msgSender() == tokenOwner, "UNAUTHORIZED"); // Token owner or delegate can stake
+
+        // Track the staking session with some off-chain metadata
+        TablelandDeployments.get().mutate(
+            address(this),
+            _tokenRepTableId,
+            SQLHelpers.toInsert(
+                _REPUTATION_PREFIX,
+                _tokenRepTableId,
+                "token_id,owner,start_time",
+                string.concat(
+                    Strings.toString(uint64(tokenId)), // Some implementation-specific casting
+                    ",",
+                    SQLHelpers.quote(Strings.toHexString(tokenOwner)), // Track reputation for the token owner
+                    ",",
+                    Strings.toString(uint64(block.number)) // Track the staking block number starting point
+                )
+            )
+        );
+        emit Stake(tokenId, tokenOwner, block.number);
+    }
+
+    function unstake(uint256 tokenId) external {
+        address tokenOwner = _ownerOf(tokenId);
+        require(_msgSender() == tokenOwner, "UNAUTHORIZED"); // Token owner or delegate can unstake
+
+        // Update the metadata's `end_time` to accrue block-based reputation, ending at the current `block.number`
+        string memory setters = string.concat(
+            "end_time=",
+            Strings.toString(uint64(block.number))
+        );
+        // Only update the row with the matching `token_id` and without an `end_time` (i.e., unfinished staking session)
+        string memory filters = string.concat(
+            "token_id=",
+            Strings.toString(uint64(tokenId)),
+            " AND ",
+            "end_time IS NULL"
+        );
+        // Update the token reputation data by ending the current block-based staking session
+        TablelandDeployments.get().mutate(
+            address(this),
+            _tokenRepTableId,
+            SQLHelpers.toUpdate(
+                _REPUTATION_PREFIX,
+                _tokenRepTableId,
+                setters,
+                filters
+            )
+        );
+        emit Unstake(tokenId, tokenOwner, block.number);
+    }
+
+    function supportsInterface(bytes4 interfaceID) public view override(ERC721) returns (bool) {
+        return
+            super.supportsInterface(interfaceID) || // Both ERC-165 & ERC-721 support
+            interfaceID == 0x88832242; // Token reputation support
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata) public pure returns (bytes4) {
+        return 0x150b7a02; // Allows this reputation contract to own NFTs, which may be useful in certain cases
+    }
+}
+```
+
+## Security Considerations
+
+The same security considerations as [ERC-721](https://eips.ethereum.org/EIPS/eip-721) apply.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/research/eip-draft_token_reputation.md
+++ b/research/eip-draft_token_reputation.md
@@ -1,7 +1,7 @@
 ---
 title: Token-based reputation
 description: A minimal ERC-721 extension for token-based reputation.
-author: Daniel Buchholz (@dtbuchholz) <dan@tableland.xyz>, Sander Pick (@sanderpick) <sander@tableland.xyz>, datadanne (@datadanne_eth)
+author: Daniel Buchholz (@dtbuchholz) <dan@tableland.xyz>, Sander Pick (@sanderpick) <sander@tableland.xyz>, datadanne (@datadanne)
 discussions-to: https://github.com/ethereum/eips/issues/<EIP_NUMBER> # TODO: Update
 status: Draft
 type: Standards Track

--- a/research/eip-draft_token_reputation.md
+++ b/research/eip-draft_token_reputation.md
@@ -37,6 +37,14 @@ These two EIPs also lack the emittance of a `block.number` within their events. 
 
 For reference, [OpenSea](https://docs.opensea.io/docs/metadata-standards#disable-trading-for-staked-or-locked-tokens) leverages both of the events noted in EIP-5192 and EIP-5753 to disable trading for staked/locked tokens. There are other accepted events by OpenSea, including the `Stake` and `Unstake` events outlined in this proposal, which _do not_ have an EIP associated with them. Although it is not necessarily the primary motivation of this token reputation EIP, it's been noted to demonstrate how marketplaces are using this EIP's event definitions today. In other words, it is true that the events outlined in this proposal **will disable/enable trading a token on marketplaces**; this proposal _already_ has real-world usage.
 
+### Transferrable vs. non-transferrable
+
+Generally, there are two ways to approach reputation: transferrable or non-transferrable. This EIP gives flexibility as to how reputation is treated and results in a broader use case surface area. With the `Stake` and `Unstake` events, there is information about both the token ID and current owner's address; the metadata is ultimately what stores this information. It brings a unique design advantage because it allows the NFT to simply be a _reputation proxy_ where the implementor aggregates reputation tied to a specific owner's _address_. Alternatively, the _token ID_ and that alone could be used. Reputation can either be an address-bound or token-bound.
+
+If reputation **SHOULD NOT be transferrable** (e.g., reputation SHOULD be earned for only a single owner of a token), then this EIP gives the flexibility to the implementor to block transfers, such as creating SBTs via inheriting from ERC-5192 and block sales altogether. This would ensure reputation is no longer transferrable, which is common for credentialing systems.
+
+On the contrary, if reputation is tied to the NFT token ID and not a single address, then it actually opens up a new set of opportunities for value creation through **reputation transferability**. For example, in a gaming application, you might earn some reputation that's bound to the token ID, and this unlocks a set of new features that are not available to tokens with a lower reputation. A token-gated workflow. As the token owner, you can choose to sell the token for all of the work you've put in; the tokens with more reputation are more valuable and come with transferrable game state. The owner could even choose to participate in more complex activities, like temporarily allowing another account to own the token (e.g., rent / escrow) and profit from the reputation earned.
+
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.

--- a/research/eip-draft_token_reputation.md
+++ b/research/eip-draft_token_reputation.md
@@ -37,7 +37,7 @@ These two EIPs also lack the emittance of a `block.number` within their events. 
 
 For reference, [OpenSea](https://docs.opensea.io/docs/metadata-standards#disable-trading-for-staked-or-locked-tokens) leverages both of the events noted in EIP-5192 and EIP-5753 to disable trading for staked/locked tokens. There are other accepted events by OpenSea, including the `Stake` and `Unstake` events outlined in this proposal, which _do not_ have an EIP associated with them. Although it is not necessarily the primary motivation of this token reputation EIP, it's been noted to demonstrate how marketplaces are using this EIP's event definitions today. In other words, it is true that the events outlined in this proposal **will disable/enable trading a token on marketplaces**; this proposal _already_ has real-world usage.
 
-### Transferrable vs. non-transferrable
+### Transferrable vs. Non-Transferrable
 
 Generally, there are two ways to approach reputation: transferrable or non-transferrable. This EIP gives flexibility as to how reputation is treated and results in a broader use case surface area. With the `Stake` and `Unstake` events, there is information about both the token ID and current owner's address; the metadata is ultimately what stores this information. It brings a unique design advantage because it allows the NFT to simply be a _reputation proxy_ where the implementor aggregates reputation tied to a specific owner's _address_. Alternatively, the _token ID_ and that alone could be used. Reputation can either be an address-bound or token-bound.
 


### PR DESCRIPTION
This PR implements token-based reputation. It is inclusive of a draft (unsubmitted) EIP located in `research`, the minimal `ITokenReputation` interface, and associated adjustments to other contracts and tests.

In relation to the EIP, the following provides more detail and can be found at `research/eip-draft_token_reputation.md`:
- This is the core EIP for token-based reputation. It is a minimal interface that simply has staking & unstaking methods along with events; the design is to be as lightweight as possible and hone in on metadata having the "value" and storing reputation using indexed events / data availability.
- There is an ERC-165 interface ID, which _should be_ correct for the supplied token reputation contract—the code to generate this ID was with `type(ITokenReputation).interfaceId`, which is `0x88832242`.
- With a partial goal of EIP acceptance, the majority of the EIP focuses on non-Tableland specific features and includes real-world usage by OpenSea today. [OS disables transfers](https://docs.opensea.io/docs/metadata-standards#disable-trading-for-staked-or-locked-tokens) on a `Stake` event as long as it includes a `tokenId` parameter; it can include additional params and still works as expected (according to the OS support team). The `Unstake` event will re-enable sales.
- At the end of the EIP, two example implementations are provided. The first is generic but at least names the ERC721 token and `baseURI` with Tableland.
- The second example is very Tableland specific (SQLHelpers, TablelandDeployments, gateway query) and tries to sort of justify the Tableland-specific example using the comments to explain what the dynamic metadata does at a high level.
  - This example is fully functional (you can deploy the code) but, perhaps, isn't the "most real" implementation; however, an EIP must be as generic as possible, so this was the ultimate idea with the attempt.
  - The contract creates a pilot sessions like setup and inserts/updates table data; the `tokenURI` queries the Tableland gateway with a `select` statement that forms a basic `attributes` array, calculating `Reputation` with a naive `end_time` minus `start_time` (i.e., no aggregate sum; just a basic example of a row's reputation score).

With the `ITokenReputation.sol` contract, it has been implemented by the `TablelandRigs.sol` contract. This was easier than doing so in `TablelandPilots.sol` as the function signature was more aligned to the core Rigs contract. It was rather straightforward to drop it in, which is a good sign from a usability standpoint (only took a few mins to adjust the exist train / pilot / park methods and tests). Note that this does not change any core contract logic but only method names; external apps like The Garage are affected since the Rigs Garage functions are now different. Lastly, a couple of tests were also added.

Closes [REA-2](https://linear.app/tableland/issue/REA-2/write-preliminary-eip), [REA-3](https://linear.app/tableland/issue/REA-3/implement-generic-contract-interfaces).