### PR TITLE
Garage: Improve piloting UI

### DIFF
--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -15,7 +15,7 @@
         "@rainbow-me/rainbowkit": "^0.12.12",
         "@tableland/rigs": "^0.2.0",
         "@tableland/sdk": "^4.0.0-pre.8",
-        "alchemy-sdk": "^2.2.5",
+        "alchemy-sdk": "^2.8.3",
         "chakra-react-select": "^4.4.2",
         "delegatecash": "^0.4.1",
         "ethers": "^5.7.2",
@@ -4562,9 +4562,9 @@
       "integrity": "sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA=="
     },
     "node_modules/alchemy-sdk": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-2.2.5.tgz",
-      "integrity": "sha512-PUSNyV1bTkSl4fsmDG7H68h2gKETnwKSVjINxuPsj8rv2PpUJuRYTuMFHUdZBEUifQ2WkbciB80OEbwvTl3xAA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/alchemy-sdk/-/alchemy-sdk-2.8.3.tgz",
+      "integrity": "sha512-JyJt62udg4kCBCQtG64q4cE74pFuH73+FEWVDrA5VfffmVBmCMYK8kJQyfyacqVZrjO0LzpULt3C7ELc+saRyQ==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/abstract-provider": "^5.7.0",

--- a/garage/package.json
+++ b/garage/package.json
@@ -16,7 +16,7 @@
     "@rainbow-me/rainbowkit": "^0.12.12",
     "@tableland/rigs": "^0.2.0",
     "@tableland/sdk": "^4.0.0-pre.8",
-    "alchemy-sdk": "^2.2.5",
+    "alchemy-sdk": "^2.8.3",
     "chakra-react-select": "^4.4.2",
     "delegatecash": "^0.4.1",
     "ethers": "^5.7.2",

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -502,6 +502,18 @@ const useFilters = <T,>() => {
   return { filters, toggleFilter, clearFilters };
 };
 
+// The pilot contract packs pilot struct data and requires that the pilot token id
+// is < type(uint32).max
+const MAX_SUPPORTED_PILOT_TOKEN_ID = ethers.BigNumber.from("0xFFFFFFFF");
+
+const tryParseBigNumber = (v: any) => {
+  try {
+    return { valid: true, result: ethers.BigNumber.from(v) };
+  } catch (_) {
+    return { valid: false, result: ethers.BigNumber.from(0) };
+  }
+};
+
 const PickRigPilotStep = ({
   rigs,
   pilots,
@@ -634,9 +646,13 @@ const PickRigPilotStep = ({
         <Flex direction="row" wrap="wrap" justify="start" gap={4}>
           {nfts &&
             nfts.map((nft, index) => {
+              const { valid, result: tokenId } = tryParseBigNumber(nft.tokenId);
               const supported =
                 nft.type === "ERC721" &&
-                nft.contract.toLowerCase() !== contractAddress.toLowerCase();
+                nft.contract.toLowerCase() !== contractAddress.toLowerCase() &&
+                valid &&
+                MAX_SUPPORTED_PILOT_TOKEN_ID.gte(tokenId);
+
               const alreadySelected = Object.values(pilots).includes(nft);
 
               const selectedForCurrentRig = pilot === nft;

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -650,6 +650,7 @@ const PickRigPilotStep = ({
               const supported =
                 nft.type === "ERC721" &&
                 nft.contract.toLowerCase() !== contractAddress.toLowerCase() &&
+                !!(nft.imageData || nft.imageUrl || nft.highResImageUrl) &&
                 valid &&
                 MAX_SUPPORTED_PILOT_TOKEN_ID.gte(tokenId);
 

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -59,6 +59,7 @@ import { abi } from "../abis/TablelandRigs";
 import { copySet, toggleInSet } from "../utils/set";
 import { pluralize } from "../utils/fmt";
 import { isPresent, isValidAddress, as0xString } from "../utils/types";
+import unknownPilot from "../assets/unknown-pilot.svg";
 
 const { contractAddress } = deployment;
 
@@ -373,6 +374,7 @@ const NFTDisplay = ({
     >
       <Image
         src={nft.imageUrl || nft.imageData}
+        fallbackSrc={unknownPilot}
         width={size}
         sx={{ aspectRatio: "1/1", objectFit: "contain" }}
       />

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -65,11 +65,13 @@ export const toNFT = (data: Nft): NFT => {
   const highResImageUrl = media[0]?.gateway || media[0]?.raw;
   const imageData = rawMetadata?.image_data || rawMetadata?.svg_image_data;
 
+  const fallbackName = (contract.name + " " + tokenId).trim();
+
   return {
     type: toNFTType(contract.tokenType),
     contract: contract.address,
     tokenId,
-    name: title,
+    name: title || fallbackName,
     imageUrl,
     highResImageUrl,
     imageData,

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -123,7 +123,7 @@ const fetchNftsForOwner = async (
     pageSize,
     pageKey,
     omitMetadata: false,
-    excludeFilters: [NftFilters.SPAM],
+    excludeFilters: [NftFilters.SPAM, NftFilters.AIRDROPS],
   };
   if (filter?.contracts) {
     options = { ...options, contractAddresses: filter.contracts };

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -35,8 +35,14 @@ const settings = {
 
 export const alchemy = new Alchemy(settings);
 
+enum NFTType {
+  ERC721 = "ERC721",
+  ERC1155 = "ERC1155",
+  UNKNOWN = "UNKNOWN",
+}
+
 export interface NFT {
-  type: "ERC721" | "ERC1155" | "UNKNOWN";
+  type: NFTType;
   contract: string;
   tokenId: string;
   name?: string;
@@ -44,6 +50,13 @@ export interface NFT {
   highResImageUrl?: string;
   imageData?: string;
 }
+
+const toNFTType = (t: Nft["tokenType"]): NFTType => {
+  if (t === "ERC721") return NFTType.ERC721;
+  if (t === "ERC1155") return NFTType.ERC1155;
+
+  return NFTType.UNKNOWN;
+};
 
 export const toNFT = (data: Nft): NFT => {
   const { contract, tokenId, title, media, rawMetadata } = data;
@@ -53,7 +66,7 @@ export const toNFT = (data: Nft): NFT => {
   const imageData = rawMetadata?.image_data || rawMetadata?.svg_image_data;
 
   return {
-    type: contract.tokenType,
+    type: toNFTType(contract.tokenType),
     contract: contract.address,
     tokenId,
     name: title,

--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -230,38 +230,15 @@ export const useNFTCollections = (contracts?: string[]) => {
       return { ...oldData, isLoading: true, isError: false };
     });
 
-    const options = {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-      },
-      body: JSON.stringify({
-        contractAddresses: contracts,
-      }),
-    };
+    alchemy.nft.getContractMetadataBatch(contracts).then((data) => {
+      if (isCancelled) return;
 
-    fetch(
-      `https://${settings.network}.g.alchemy.com/nft/v2/${
-        import.meta.env.VITE_ALCHEMY_ID
-      }/getContractMetadataBatch`,
-      options
-    )
-      .then((response) => response.json())
-      .then((response) => {
-        if (isCancelled) return;
-
-        const data = (response as any[]).filter((v) => v?.address);
-
-        setData({
-          isLoading: false,
-          isError: false,
-          collections: data.map(({ address, contractMetadata }) =>
-            toCollection({ address, ...contractMetadata })
-          ),
-        });
-      })
-      .catch((err) => console.error(err));
+      setData({
+        isLoading: false,
+        isError: false,
+        collections: data.map(toCollection),
+      });
+    });
 
     return () => {
       isCancelled = true;


### PR DESCRIPTION
A user reported that they weren't able to pilot a rig using a token from the MAX PAIN AND FRENS collection so I looked into it and it turns out that the collection is using token ids larger than `type(uint32).max` (`0xFFFFFF`) which our pilot contract doesn't support because of a packing optimization we made in the pilot info struct (I dunno why they use those IDs, the collection has < 10k tokens but token ids don't start at 0). As I was looking into that I was using the garage as that user and noticed that we weren't filtering out a bunch of garbage tokens from the pilot UI, so I made some tweaks to the piloting UI. 

Changes:
- Filter out airdropped NFTs. The alchemy API does a pretty bad job at filtering out scam NFTs (and doesn't support filtering on ERC721 / ERC1155..), filtering out airdropped NFTs removes most of the scam 1155s
- Filter out ERC721s with tokenId > `0xFFFFFF` because the pilot contract doesn't support them
- Add a fallback image for NFTs without a valid image uri
- Add a fallback way of parsing a token name if the tokenUri is invalid (collection name + tokenId)
- Updated the alchemy sdk so that we can use the newly added `getContractMetadataBatch` sdk method instead of manually calling their api using `fetch`


Before:
![image](https://github.com/tablelandnetwork/rigs/assets/656107/56c9bb42-cf1e-44cf-8036-4e981e003c70)

After:
![image](https://github.com/tablelandnetwork/rigs/assets/656107/e8ad3968-8341-49f9-bbdd-ec53f81a2888)
