### PR TITLE
feat: migrate to upgraded `wagmi`, `rainbowkit`

### DIFF
--- a/garage/package-lock.json
+++ b/garage/package-lock.json
@@ -12,7 +12,7 @@
         "@chakra-ui/react": "^2.3.4",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
-        "@rainbow-me/rainbowkit": "^0.12.12",
+        "@rainbow-me/rainbowkit": "^1.0.3",
         "@tableland/rigs": "^0.3.0",
         "@tableland/sdk": "^4.3.2",
         "alchemy-sdk": "^2.8.3",
@@ -25,17 +25,23 @@
         "react-dom": "^18.2.0",
         "react-query": "^3.39.3",
         "react-router-dom": "^6.4.3",
-        "wagmi": "^0.12.12"
+        "viem": "~1.0.6",
+        "wagmi": "~1.2.0"
       },
       "devDependencies": {
         "@types/react": "^18.0.38",
         "@types/react-dom": "^18.2.1",
         "@vitejs/plugin-react": "^3.1.0",
-        "typescript": "^4.6.4",
+        "typescript": "^5.1.3",
         "vite": "^4.3.2",
         "vite-plugin-ejs": "^1.6.4",
         "vite-plugin-svgr": "^2.4.0"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.9.0.tgz",
+      "integrity": "sha512-iowxq3U30sghZotgl4s/oJRci6WPBfNO5YYgk2cIOMCHr3LeGPcsZjCEr+33Q4N+oV3OABDAtA+pyvWjbvBifQ=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",
@@ -1492,9 +1498,9 @@
       }
     },
     "node_modules/@coinbase/wallet-sdk": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.6.6.tgz",
-      "integrity": "sha512-vX+epj/Ttjo7XRwlr3TFUUfW5GTRMvORpERPwiu7z2jl3DSVL4rXLmHt5y6LDPlUVreas2gumdcFbu0fLRG9Jg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-3.7.1.tgz",
+      "integrity": "sha512-LjyoDCB+7p0waQXfK+fUgcAs3Ezk6S6e+LYaoFjpJ6c9VTop3NyZF40Pi7df4z7QJohCwzuIDjz0Rhtig6Y7Pg==",
       "dependencies": {
         "@metamask/safe-event-emitter": "2.0.0",
         "@solana/web3.js": "^1.70.1",
@@ -2785,9 +2791,9 @@
       }
     },
     "node_modules/@ledgerhq/connect-kit-loader": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.0.2.tgz",
-      "integrity": "sha512-TQ21IjcZOw/scqypaVFY3jHVqI7X7Hta3qN/us6FvTol3AY06UmrhhXGww0E9xHmAbdX241ddwXEiMBSQZFr9g=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ledgerhq/connect-kit-loader/-/connect-kit-loader-1.1.0.tgz",
+      "integrity": "sha512-HUy12FEczoWY2FPubnsm1uOA8tkVWc0j90i47suThV3C9NL2xx69ZAIEU3Ytzs2bwLek9S1Q2S1VQJvA+3Ygkg=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.1.1",
@@ -2795,9 +2801,9 @@
       "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.2.tgz",
+      "integrity": "sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
@@ -2822,9 +2828,9 @@
       }
     },
     "node_modules/@metamask/utils/node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2854,6 +2860,19 @@
         "tslib": "^2.3.1"
       }
     },
+    "node_modules/@motionone/dom": {
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.16.2.tgz",
+      "integrity": "sha512-bnuHdNbge1FutZXv+k7xub9oPWcF0hsu8y1HTH/qg6av58YI0VufZ3ngfC7p2xhMJMnoh0LXFma2EGTgPeCkeg==",
+      "dependencies": {
+        "@motionone/animation": "^10.15.1",
+        "@motionone/generators": "^10.15.1",
+        "@motionone/types": "^10.15.1",
+        "@motionone/utils": "^10.15.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
     "node_modules/@motionone/easing": {
       "version": "10.15.1",
       "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
@@ -2874,24 +2893,11 @@
       }
     },
     "node_modules/@motionone/svelte": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.15.5.tgz",
-      "integrity": "sha512-Xyxtgp7BlVnSBwcoFmXGHUVnpNktzeXsEifu2NJJWc7VGuxutDsBZxNdz80qvpLIC5MeBa1wh7GGegZzTm1msg==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/svelte/-/svelte-10.16.2.tgz",
+      "integrity": "sha512-38xsroKrfK+aHYhuQlE6eFcGy0EwrB43Q7RGjF73j/kRUTcLNu/LAaKiLLsN5lyqVzCgTBVt4TMT/ShWbTbc5Q==",
       "dependencies": {
-        "@motionone/dom": "^10.15.5",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/svelte/node_modules/@motionone/dom": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
-      "integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
-      "dependencies": {
-        "@motionone/animation": "^10.15.1",
-        "@motionone/generators": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "hey-listen": "^1.0.8",
+        "@motionone/dom": "^10.16.2",
         "tslib": "^2.3.1"
       }
     },
@@ -2911,53 +2917,32 @@
       }
     },
     "node_modules/@motionone/vue": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.15.5.tgz",
-      "integrity": "sha512-cUENrLYAolUacHvCgU+8wF9OgSlVutfWbHMLERI/bElCJ+e2YVQvG/CpGhIM5fYOOJzuvg2T2wHmLLmvJoavEw==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/@motionone/vue/-/vue-10.16.2.tgz",
+      "integrity": "sha512-7/dEK/nWQXOkJ70bqb2KyNfSWbNvWqKKq1C8juj+0Mg/AorgD8O5wE3naddK0G+aXuNMqRuc4jlsYHHWHtIzVw==",
       "dependencies": {
-        "@motionone/dom": "^10.15.5",
+        "@motionone/dom": "^10.16.2",
         "tslib": "^2.3.1"
       }
     },
-    "node_modules/@motionone/vue/node_modules/@motionone/dom": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
-      "integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
-      "dependencies": {
-        "@motionone/animation": "^10.15.1",
-        "@motionone/generators": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@noble/ed25519": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
-      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+    "node_modules/@noble/curves": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.0.0.tgz",
+      "integrity": "sha512-2upgEu0iLiDVDZkNLeFV2+ht0BAVgQnEmCk6JsOch9Rp8xfkMCbvbAZlA2pBHQc73dbl+vFOXfqkf4uemdn0bw==",
       "funding": [
         {
           "type": "individual",
           "url": "https://paulmillr.com/funding/"
         }
-      ]
+      ],
+      "dependencies": {
+        "@noble/hashes": "1.3.0"
+      }
     },
     "node_modules/@noble/hashes": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
       "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
-    },
-    "node_modules/@noble/secp256k1": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
-      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
       "funding": [
         {
           "type": "individual",
@@ -2985,9 +2970,9 @@
       }
     },
     "node_modules/@rainbow-me/rainbowkit": {
-      "version": "0.12.12",
-      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-0.12.12.tgz",
-      "integrity": "sha512-9PxYjX8Z/FOdYkzJe7BCa1qsr8hsdw8ZIOrQvB5EyolI1mdmKVIsPFTjXx85D6GY8v9P6Ax9elDDT/PdPPhgCw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rainbow-me/rainbowkit/-/rainbowkit-1.0.3.tgz",
+      "integrity": "sha512-42rqgv22V0S1c5ukjVYuNlQxenzAqGBJBdIOTp+nryw92JL5C5jJT/FJgFsObZzjK/2rGIy0SbP7WgbWRVuROw==",
       "dependencies": {
         "@vanilla-extract/css": "1.9.1",
         "@vanilla-extract/dynamic": "2.0.2",
@@ -3000,10 +2985,10 @@
         "node": ">=12.4"
       },
       "peerDependencies": {
-        "ethers": ">=5.5.1",
         "react": ">=17",
         "react-dom": ">=17",
-        "wagmi": "0.12.x"
+        "viem": "~0.3.19 || ^1.0.0",
+        "wagmi": "~1.0.1 || ~1.1.0 || ~1.2.0"
       }
     },
     "node_modules/@rainbow-me/rainbowkit/node_modules/react-remove-scroll": {
@@ -3079,9 +3064,9 @@
       }
     },
     "node_modules/@safe-global/safe-apps-sdk": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.10.1.tgz",
-      "integrity": "sha512-2imnqAbx9XrqT3psrhe/YVpj2yW840ngJIuqv0nTiWJLKcTCzM2LJ4MH7ir7H8Sp2wdG/BqNB3SvjUAks2qNjQ==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-7.11.0.tgz",
+      "integrity": "sha512-RDamzPM1Lhhiiz0O+Dn6FkFqIh47jmZX+HCV/BBnBBOSKfBJE//IGD3+02zMgojXHTikQAburdPes9qmH1SA1A==",
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "ethers": "^5.7.2"
@@ -3093,6 +3078,48 @@
       "integrity": "sha512-O6JCgXNZWG0Vv8FnOEjKfcbsP0WxGvoPJk5ufqUrsyBlHup16It6oaLnn+25nXFLBZOHI1bz8429JlqAc2t2hg==",
       "dependencies": {
         "cross-fetch": "^3.1.5"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.0.tgz",
+      "integrity": "sha512-bcKpo1oj54hGholplGLpqPHRbIsnbixFtc06nwuNM5/dwSXOq/AAYoIBRsBmnZJSdfeNW5rnff7NTAz3ZCqR9Q==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/curves": "~1.0.0",
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.0.tgz",
+      "integrity": "sha512-SX/uKq52cuxm4YFXWFaVByaSHJh2w3BnokVSeUJVCv6K7WulT9u2BuNRBhuFl8vAuYnzx9bEu9WgpcNYTrYieg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
       }
     },
     "node_modules/@solana/buffer-layout": {
@@ -3107,14 +3134,13 @@
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.75.0",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.75.0.tgz",
-      "integrity": "sha512-rHQgdo1EWfb+nPUpHe4O7i8qJPELHKNR5PAZRK+a7XxiykqOfbaAlPt5boDWAGPnYbSv0ziWZv5mq9DlFaQCxg==",
+      "version": "1.77.3",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.77.3.tgz",
+      "integrity": "sha512-PHaO0BdoiQRPpieC1p31wJsBaxwIOWLh8j2ocXNKX8boCQVldt26Jqm2tZE4KlrvnCIV78owPLv1pEUgqhxZ3w==",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@noble/ed25519": "^1.7.0",
-        "@noble/hashes": "^1.1.2",
-        "@noble/secp256k1": "^1.6.3",
+        "@noble/curves": "^1.0.0",
+        "@noble/hashes": "^1.3.0",
         "@solana/buffer-layout": "^4.0.0",
         "agentkeepalive": "^4.2.1",
         "bigint-buffer": "^1.1.5",
@@ -3123,7 +3149,7 @@
         "bs58": "^4.0.1",
         "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
-        "jayson": "^3.4.4",
+        "jayson": "^4.1.0",
         "node-fetch": "^2.6.7",
         "rpc-websockets": "^7.5.1",
         "superstruct": "^0.14.2"
@@ -3535,20 +3561,20 @@
       "integrity": "sha512-M8lMrONHowCpGVT66rTnIrnLfuwCv1zJ5MBrvZsAFb1GtAYtj8WFxoKSl65loejksez/9ftTettLqAcrrNLqNQ=="
     },
     "node_modules/@tanstack/query-core": {
-      "version": "4.29.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.5.tgz",
-      "integrity": "sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==",
+      "version": "4.29.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.29.17.tgz",
+      "integrity": "sha512-iDbO8yZOpm1lqgq6L8mpxGbKaoiyZSjthxEB3WGU7mNPYss9q4H3Q67+e2xXGwkemEVmtEX/WwvtFitrvVU8TA==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/query-persist-client-core": {
-      "version": "4.29.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.29.5.tgz",
-      "integrity": "sha512-IjLtEZiEUnzpcFVdHoZGqtjv2g0smLK5WOWk8hP/2ndlXe5kaSbtCKWO2WFbw7yWPYVMM2m9zyglZqg5kU1DMA==",
+      "version": "4.29.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-4.29.17.tgz",
+      "integrity": "sha512-NYTNfCGhvrCBdOxN3Y+IpuTlskhrtWfQDdg2y3qfFpGg2mRmu2knl99a590zzrTuSKIOhT8y+eL77BUWHBEJLg==",
       "dependencies": {
-        "@tanstack/query-core": "4.29.5"
+        "@tanstack/query-core": "4.29.17"
       },
       "funding": {
         "type": "github",
@@ -3556,11 +3582,11 @@
       }
     },
     "node_modules/@tanstack/query-sync-storage-persister": {
-      "version": "4.29.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.29.5.tgz",
-      "integrity": "sha512-A5K2owrQ1z/Ipndt/thv3vMXjRPOT02jwlXM51OV5IHg4FLQ9vlXvImYWlBoHmY1MMl91x9bqRgz0gX6hnr14g==",
+      "version": "4.29.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-4.29.17.tgz",
+      "integrity": "sha512-WvGtxcHE1iWZaP9p8qzM9IX7IL+EQ/Ci3Fzy4b/qAQ7tB3GWs6v1yo4ky5KnBOvqnCX+CdBN7ZetSrpF8oz+/g==",
       "dependencies": {
-        "@tanstack/query-persist-client-core": "4.29.5"
+        "@tanstack/query-persist-client-core": "4.29.17"
       },
       "funding": {
         "type": "github",
@@ -3568,11 +3594,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "4.29.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.5.tgz",
-      "integrity": "sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==",
+      "version": "4.29.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.29.17.tgz",
+      "integrity": "sha512-udOy/jgqiBHBAP93YPAU3QoVYO+Rtx9HT/10xGDQzC8iQU/wIxcIaT/usX+1NSzoUFYU5hUcPaNErPWZnR7XgA==",
       "dependencies": {
-        "@tanstack/query-core": "4.29.5",
+        "@tanstack/query-core": "4.29.17",
+        "client-only": "0.0.1",
         "use-sync-external-store": "^1.2.0"
       },
       "funding": {
@@ -3594,18 +3621,19 @@
       }
     },
     "node_modules/@tanstack/react-query-persist-client": {
-      "version": "4.29.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.29.5.tgz",
-      "integrity": "sha512-zvQChSqO/HpRHWjCn+4L4M45Yr2eslogJcQr2HFxRw27Wj/5WlFYhnQFo5SCCR+gZh09tMnkzD+zFhN76wMEGw==",
+      "version": "4.29.17",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-4.29.17.tgz",
+      "integrity": "sha512-wy8QL1VWAhlACE0/nMuIRkDr8Ut+qd0Q+5u0jaIOOts6sLBL5xtP4cXWz80+MTGd2IQP2bvKvuXOWbw791ATIA==",
       "dependencies": {
-        "@tanstack/query-persist-client-core": "4.29.5"
+        "@tanstack/query-persist-client-core": "4.29.17",
+        "client-only": "0.0.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "4.29.5"
+        "@tanstack/react-query": "4.29.17"
       }
     },
     "node_modules/@types/connect": {
@@ -3617,9 +3645,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
-      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
+      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -3836,9 +3864,9 @@
       }
     },
     "node_modules/@wagmi/chains": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/@wagmi/chains/-/chains-0.2.19.tgz",
-      "integrity": "sha512-pyqGjOscXH/ZFUJni+VpKmVIENz/vsgq2sgqpNAmLQ6h7/DYrzRvptij+b62K5wONZMr+7X2J5mHM9s4tkEd6A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@wagmi/chains/-/chains-1.1.0.tgz",
+      "integrity": "sha512-pWZlxBk0Ql8E7DV8DwqlbBpOyUdaG9UDlQPBxJNALuEK1I0tbQ3AVvSDnlsEIt06UPmPo5o27gzs3hwPQ/A+UA==",
       "funding": [
         {
           "type": "gitcoin",
@@ -3850,57 +3878,18 @@
         }
       ],
       "peerDependencies": {
-        "typescript": ">=4.9.4"
+        "typescript": ">=5.0.4"
       },
       "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wagmi/connectors": {
-      "version": "0.3.16",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-0.3.16.tgz",
-      "integrity": "sha512-WtiFyvai6IWbV7DhujjmtJF0m+FFQCiIDrtHsNf1xio0gBfpnO8rT9PZQQf0uxuLn0nLxqXqYMMwzPipUNaIcg==",
-      "funding": [
-        {
-          "type": "gitcoin",
-          "url": "https://wagmi.sh/gitcoin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "dependencies": {
-        "@coinbase/wallet-sdk": "^3.6.4",
-        "@ledgerhq/connect-kit-loader": "^1.0.1",
-        "@safe-global/safe-apps-provider": "^0.15.2",
-        "@safe-global/safe-apps-sdk": "^7.9.0",
-        "@walletconnect/ethereum-provider": "2.7.0",
-        "@walletconnect/legacy-provider": "^2.0.0",
-        "@web3modal/standalone": "^2.3.0",
-        "abitype": "^0.3.0",
-        "eventemitter3": "^4.0.7"
-      },
-      "peerDependencies": {
-        "@wagmi/core": ">=0.9.x",
-        "ethers": ">=5.5.1 <6",
-        "typescript": ">=4.9.4"
-      },
-      "peerDependenciesMeta": {
-        "@wagmi/core": {
-          "optional": true
-        },
         "typescript": {
           "optional": true
         }
       }
     },
     "node_modules/@wagmi/core": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-0.10.10.tgz",
-      "integrity": "sha512-oghQIASk+QfrRku2m36NJTZnj5gpJNqfID5G3kZlBReWr01iOFbGfTVcS6Pcu2X3rsR2lmky8Tu5DWLXdKeGZg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@wagmi/core/-/core-1.2.2.tgz",
+      "integrity": "sha512-iwg72KYJ1XV8PVsVg3rF1I6K8IwcF4zksLs4drP1a0f7wWjWXcfwmmq+nuRkkr1OQp2rQYF2lwmAlqoElcA4uw==",
       "funding": [
         {
           "type": "gitcoin",
@@ -3912,15 +3901,15 @@
         }
       ],
       "dependencies": {
-        "@wagmi/chains": "0.2.19",
-        "@wagmi/connectors": "0.3.16",
-        "abitype": "^0.3.0",
+        "@wagmi/chains": "1.3.0",
+        "@wagmi/connectors": "2.4.0",
+        "abitype": "0.8.7",
         "eventemitter3": "^4.0.7",
         "zustand": "^4.3.1"
       },
       "peerDependencies": {
-        "ethers": ">=5.5.1 <6",
-        "typescript": ">=4.9.4"
+        "typescript": ">=5.0.4",
+        "viem": ">=0.3.35"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -3928,14 +3917,77 @@
         }
       }
     },
+    "node_modules/@wagmi/core/node_modules/@wagmi/chains": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@wagmi/chains/-/chains-1.3.0.tgz",
+      "integrity": "sha512-7tyr1irTZQpA4/4HoIiJP3XYZuJIZuWiZ1V1j5WEG3cjm8TXIlMEzO0N+hT/cZKw4/UtF2EukvB8GkDWa2S77w==",
+      "funding": [
+        {
+          "type": "gitcoin",
+          "url": "https://wagmi.sh/gitcoin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@wagmi/core/node_modules/@wagmi/connectors": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-2.4.0.tgz",
+      "integrity": "sha512-v9h2B3g84uOnZeVEVW+dCw0nASGl31tVtzGtzkm3C8irpA+dCmTVSHe4oEHxA6FIuABsI5egKXkWVxdE0/jLzg==",
+      "funding": [
+        {
+          "type": "gitcoin",
+          "url": "https://wagmi.sh/gitcoin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "dependencies": {
+        "@coinbase/wallet-sdk": "^3.6.6",
+        "@ledgerhq/connect-kit-loader": "^1.1.0",
+        "@safe-global/safe-apps-provider": "^0.15.2",
+        "@safe-global/safe-apps-sdk": "^7.9.0",
+        "@walletconnect/ethereum-provider": "2.8.1",
+        "@walletconnect/legacy-provider": "^2.0.0",
+        "@walletconnect/modal": "^2.4.6",
+        "abitype": "0.8.7",
+        "eventemitter3": "^4.0.7"
+      },
+      "peerDependencies": {
+        "@wagmi/chains": ">=1.3.0",
+        "typescript": ">=5.0.4",
+        "viem": ">=0.3.35"
+      },
+      "peerDependenciesMeta": {
+        "@wagmi/chains": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@walletconnect/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-xUeFPpElybgn1a+lknqtHleei4VyuV/4qWgB1nP8qQUAO6a5pNsioODrnB2VAPdUHJYBdx2dCt2maRk6g53IPQ==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.8.1.tgz",
+      "integrity": "sha512-mN9Zkdl/NeThntK8cydDoQOW6jUEpOeFgYR1RCKPLH51VQwlbdSgvvQIeanSQXEY4U7AM3x8cs1sxqMomIfRQg==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-provider": "^1.0.12",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
+        "@walletconnect/jsonrpc-types": "1.0.3",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/jsonrpc-ws-connection": "^1.0.11",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
@@ -3943,8 +3995,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.0",
-        "@walletconnect/utils": "2.7.0",
+        "@walletconnect/types": "2.8.1",
+        "@walletconnect/utils": "2.8.1",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -4002,25 +4054,25 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/ethereum-provider": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.7.0.tgz",
-      "integrity": "sha512-6TwQ05zi6DP1TP1XNgSvLbmCmLf/sz7kLTfMaVk45YYHNgYTTBlXqkyjUpQZI9lpq+uXLBbHn/jx2OGhOPUP0Q==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/ethereum-provider/-/ethereum-provider-2.8.1.tgz",
+      "integrity": "sha512-YlF8CCiFTSEZRyANIBsop/U+t+d1Z1/UXXoE9+iwjSGKJsaym6PgBLPb2d8XdmS/qR6Tcx7lVodTp4cVtezKnA==",
       "dependencies": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
-        "@walletconnect/sign-client": "2.7.0",
-        "@walletconnect/types": "2.7.0",
-        "@walletconnect/universal-provider": "2.7.0",
-        "@walletconnect/utils": "2.7.0",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "^1.0.13",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
+        "@walletconnect/sign-client": "2.8.1",
+        "@walletconnect/types": "2.8.1",
+        "@walletconnect/universal-provider": "2.8.1",
+        "@walletconnect/utils": "2.8.1",
         "events": "^3.3.0"
       },
       "peerDependencies": {
-        "@web3modal/standalone": ">=2"
+        "@walletconnect/modal": ">=2"
       },
       "peerDependenciesMeta": {
-        "@web3modal/standalone": {
+        "@walletconnect/modal": {
           "optional": true
         }
       }
@@ -4055,9 +4107,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-http-connection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.6.tgz",
-      "integrity": "sha512-/3zSqDi7JDN06E4qm0NmVYMitngXfh21UWwy8zeJcBeJc+Jcs094EbLsIxtziIIKTCCbT88lWuTjl1ZujxN7cw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-http-connection/-/jsonrpc-http-connection-1.0.7.tgz",
+      "integrity": "sha512-qlfh8fCfu8LOM9JRR9KE0s0wxP6ZG9/Jom8M0qsoIQeKF3Ni0FyV4V1qy/cc7nfI46SLQLSl4tgWSfLiE1swyQ==",
       "dependencies": {
         "@walletconnect/jsonrpc-utils": "^1.0.6",
         "@walletconnect/safe-json": "^1.0.1",
@@ -4071,11 +4123,11 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.12.tgz",
-      "integrity": "sha512-6uI2y5281gloZSzICOjk+CVC7CVu0MhtMt2Yzpj05lPb0pzm/bK2oZ2ibxwLerPrqpNt/5bIFVRmoOgPw1mHAQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
+      "integrity": "sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==",
       "dependencies": {
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "^1.0.8",
         "@walletconnect/safe-json": "^1.0.2",
         "tslib": "1.14.1"
       }
@@ -4086,9 +4138,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-types": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.2.tgz",
-      "integrity": "sha512-CZe8tjJX73OWdHjrBHy7HtAapJ2tT0Q3TYhPBhRxi3643lwPIQWC9En45ldY14TZwgSewkbZ0FtGBZK0G7Bbyg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-types/-/jsonrpc-types-1.0.3.tgz",
+      "integrity": "sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==",
       "dependencies": {
         "keyvaluestorage-interface": "^1.0.0",
         "tslib": "1.14.1"
@@ -4100,12 +4152,12 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/jsonrpc-utils": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.7.tgz",
-      "integrity": "sha512-zJziApzUF/Il4VcwabnaU+0yo1QI4eUkYX99zmCVTHJvZOf2l0zjADf/OpKqWyeNFC3Io56Z/8uJHVtcNVvyFA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-utils/-/jsonrpc-utils-1.0.8.tgz",
+      "integrity": "sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==",
       "dependencies": {
         "@walletconnect/environment": "^1.0.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "^1.0.3",
         "tslib": "1.14.1"
       }
     },
@@ -4281,6 +4333,52 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
+    "node_modules/@walletconnect/modal": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal/-/modal-2.5.4.tgz",
+      "integrity": "sha512-JAKMcCd4JQvSEr7pNitg3OBke4DN1JyaQ7bdi3x4T7oLgOr9Y88qdkeOXko/0aJonDHJsM88hZ10POQWmKfEMA==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.5.4",
+        "@walletconnect/modal-ui": "2.5.4"
+      }
+    },
+    "node_modules/@walletconnect/modal-core": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-core/-/modal-core-2.5.4.tgz",
+      "integrity": "sha512-ISe4LqmEDFU7b6rLgonqaEtMXzG6ko13HA7S8Ty3d7GgfAEe29LM1dq3zo8ehEOghhofhj1PiiNfvaogZKzT1g==",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "valtio": "1.10.6"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui": {
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/@walletconnect/modal-ui/-/modal-ui-2.5.4.tgz",
+      "integrity": "sha512-5qLLjwbE3YC4AsCVhf8J87otklkApcQ5DCMykOcS0APPv8lKQ46JxpQhfWwRYaUkuIiHonI9h1YxFARDkoaI9g==",
+      "dependencies": {
+        "@walletconnect/modal-core": "2.5.4",
+        "lit": "2.7.5",
+        "motion": "10.16.2",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@walletconnect/modal-ui/node_modules/qrcode": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
+      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "encode-utf8": "^1.0.3",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@walletconnect/randombytes": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@walletconnect/randombytes/-/randombytes-1.0.3.tgz",
@@ -4343,18 +4441,18 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.7.0.tgz",
-      "integrity": "sha512-K99xa6GSFS04U+140yrIEi/VJJJ0Q1ov4jCaiqa9euILDKxlBsM7m5GR+9sq6oYyj18SluJY4CJTdeOXUJlarA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.8.1.tgz",
+      "integrity": "sha512-6DbpjP9BED2YZOZdpVgYo0HwPBV7k99imnsdMFrTn16EFAxhuYP0/qPwum9d072oNMGWJSA6d4rzc8FHNtHsCA==",
       "dependencies": {
-        "@walletconnect/core": "2.7.0",
+        "@walletconnect/core": "2.8.1",
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
+        "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "^2.0.1",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.0",
-        "@walletconnect/utils": "2.7.0",
+        "@walletconnect/types": "2.8.1",
+        "@walletconnect/utils": "2.8.1",
         "events": "^3.3.0"
       }
     },
@@ -4372,63 +4470,62 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.7.0.tgz",
-      "integrity": "sha512-aMUDUtO79WSBtC/bDetE6aFwdgwJr0tJ8nC8gnAl5ELsrjygEKCn6M8Q+v6nP9svG9yf5Rds4cImxCT6BWwTyw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.8.1.tgz",
+      "integrity": "sha512-MLISp85b+27vVkm3Wkud+eYCwySXCdOrmn0yQCSN6DnRrrunrD05ksz4CXGP7h2oXUvvXPDt/6lXBf1B4AfqrA==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
-        "@walletconnect/jsonrpc-types": "^1.0.2",
+        "@walletconnect/jsonrpc-types": "1.0.3",
         "@walletconnect/keyvaluestorage": "^1.0.2",
         "@walletconnect/logger": "^2.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/universal-provider": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.7.0.tgz",
-      "integrity": "sha512-aAIudO3ZlKD16X36VnXChpxBB6/JLK1SCJBfidk7E0GE2S4xr1xW5jXGSGS4Z+wIkNZXK0n7ULSK3PZ7mPBdog==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/universal-provider/-/universal-provider-2.8.1.tgz",
+      "integrity": "sha512-6shgE4PM/S+GEh9oTWMloHZlt2BLsCitRn9tBh2Vf+jZiGlug3WNm+tBc/Fo6ILyHuzeYPbkzCM67AxcutOHGQ==",
       "dependencies": {
-        "@walletconnect/jsonrpc-http-connection": "^1.0.4",
-        "@walletconnect/jsonrpc-provider": "^1.0.11",
+        "@walletconnect/jsonrpc-http-connection": "^1.0.7",
+        "@walletconnect/jsonrpc-provider": "1.0.13",
         "@walletconnect/jsonrpc-types": "^1.0.2",
         "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/logger": "^2.0.1",
-        "@walletconnect/sign-client": "2.7.0",
-        "@walletconnect/types": "2.7.0",
-        "@walletconnect/utils": "2.7.0",
+        "@walletconnect/sign-client": "2.8.1",
+        "@walletconnect/types": "2.8.1",
+        "@walletconnect/utils": "2.8.1",
         "eip1193-provider": "1.0.1",
         "events": "^3.3.0"
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.7.0.tgz",
-      "integrity": "sha512-k32jrQeyJsNZPdmtmg85Y3QgaS5YfzYSPrAxRC2uUD1ts7rrI6P5GG2iXNs3AvWKOuCgsp/PqU8s7AC7CRUscw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.8.1.tgz",
+      "integrity": "sha512-d6p9OX3v70m6ijp+j4qvqiQZQU1vbEHN48G8HqXasyro3Z+N8vtcB5/gV4pTYsbWgLSDtPHj49mzbWQ0LdIdTw==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha256": "1.0.1",
         "@stablelib/x25519": "^1.0.3",
-        "@walletconnect/jsonrpc-utils": "^1.0.7",
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.7.0",
+        "@walletconnect/types": "2.8.1",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
-        "query-string": "7.1.1",
+        "query-string": "7.1.3",
         "uint8arrays": "^3.1.0"
       }
     },
     "node_modules/@walletconnect/utils/node_modules/query-string": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.1.tgz",
-      "integrity": "sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
+      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
       "dependencies": {
-        "decode-uri-component": "^0.2.0",
+        "decode-uri-component": "^0.2.2",
         "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
@@ -4467,52 +4564,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
-    "node_modules/@web3modal/core": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@web3modal/core/-/core-2.3.7.tgz",
-      "integrity": "sha512-ggl9+tkAzz43npj97iTj6p4oQYaklxADQyCKAX7AnMfglZg5bRseMDGnfmpvnjlDn8TI+DGGO6da3ITmYRIDYQ==",
-      "dependencies": {
-        "buffer": "6.0.3",
-        "valtio": "1.10.4"
-      }
-    },
-    "node_modules/@web3modal/standalone": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@web3modal/standalone/-/standalone-2.3.7.tgz",
-      "integrity": "sha512-zgavWcimRVXnLdup2WQ0fFEnBnH+Wwn+k1/XzhwVpdJ//mrExWNYQaXt139RijxGUcux68ExRCyMqm1jkXTq3g==",
-      "dependencies": {
-        "@web3modal/core": "2.3.7",
-        "@web3modal/ui": "2.3.7"
-      }
-    },
-    "node_modules/@web3modal/ui": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/@web3modal/ui/-/ui-2.3.7.tgz",
-      "integrity": "sha512-mNDXY4ElcvXXixKHZTLcEjKC9zs3O8BD1EtaC8cKIy+RKFyHMpLB1DOQmz77tn91jNjOkrvEryqUwCbsJ7hjfA==",
-      "dependencies": {
-        "@web3modal/core": "2.3.7",
-        "lit": "2.7.3",
-        "motion": "10.15.5",
-        "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@web3modal/ui/node_modules/qrcode": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.3.tgz",
-      "integrity": "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg==",
-      "dependencies": {
-        "dijkstrajs": "^1.0.1",
-        "encode-utf8": "^1.0.3",
-        "pngjs": "^5.0.0",
-        "yargs": "^15.3.1"
-      },
-      "bin": {
-        "qrcode": "bin/qrcode"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@zag-js/element-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@zag-js/element-size/-/element-size-0.1.0.tgz",
@@ -4524,21 +4575,12 @@
       "integrity": "sha512-PeaBcTmdZWcFf7n1aM+oiOdZc+sy14qi0emPIeUuGMTjbP0xLGrZu43kdpHnWSXy7/r4Ubp/vlg50MCV8+9Isg=="
     },
     "node_modules/abitype": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.3.0.tgz",
-      "integrity": "sha512-0YokyAV4hKMcy97Pl+6QgZBlBdZJN2llslOs7kiFY+cu7kMlVXDBpxMExfv0krzBCQt2t7hNovpQ3y/zvEm18A==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "engines": {
-        "pnpm": ">=7"
-      },
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.8.7.tgz",
+      "integrity": "sha512-wQ7hV8Yg/yKmGyFpqrNZufCxbszDe5es4AZGYPBitocfSqXtjrTG9JMWFcc4N30ukl2ve48aBTwt7NJxVQdU3w==",
       "peerDependencies": {
-        "typescript": ">=4.9.4",
-        "zod": ">=3.19.1"
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.19.1"
       },
       "peerDependenciesMeta": {
         "zod": {
@@ -4971,6 +5013,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "node_modules/cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5049,30 +5096,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
+      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
       "dependencies": {
-        "node-fetch": "2.6.7"
-      }
-    },
-    "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+        "node-fetch": "^2.6.11"
       }
     },
     "node_modules/css-box-model": {
@@ -5235,6 +5263,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/eip1193-provider/-/eip1193-provider-1.0.1.tgz",
       "integrity": "sha512-kSuqwQ26d7CzuS/t3yRXo2Su2cVH0QfvyKbr2H7Be7O5YDyIq4hQGCNTo5wRdP07bt+E2R/8nPCzey4ojBHf7g==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
       "dependencies": {
         "@json-rpc-tools/provider": "^1.5.5"
       }
@@ -5562,9 +5591,9 @@
       }
     },
     "node_modules/fast-redact": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
-      "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.2.0.tgz",
+      "integrity": "sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==",
       "engines": {
         "node": ">=6"
       }
@@ -5765,12 +5794,13 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
-      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3"
       },
       "funding": {
@@ -5841,6 +5871,17 @@
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -6052,9 +6093,9 @@
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
       "peerDependencies": {
         "ws": "*"
       }
@@ -6148,9 +6189,9 @@
       }
     },
     "node_modules/jayson": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-3.7.0.tgz",
-      "integrity": "sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.1.0.tgz",
+      "integrity": "sha512-R6JlbyLN53Mjku329XoRT2zJAE6ZgOQ8f91ucYdMCD4nkGCF9kZSrcGXpHIU4jeKj58zUZke2p+cdQchU7Ly7A==",
       "dependencies": {
         "@types/connect": "^3.4.33",
         "@types/node": "^12.12.54",
@@ -6162,7 +6203,6 @@
         "isomorphic-ws": "^4.0.1",
         "json-stringify-safe": "^5.0.1",
         "JSONStream": "^1.3.5",
-        "lodash": "^4.17.20",
         "uuid": "^8.3.2",
         "ws": "^7.4.5"
       },
@@ -6177,6 +6217,14 @@
       "version": "12.20.55",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
       "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="
+    },
+    "node_modules/jayson/node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -6287,9 +6335,9 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lit": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.3.tgz",
-      "integrity": "sha512-0a+u+vVbmgSfPu+fyvqjMPBX0Kwbyj9QOv9MbQFZhWGlV2cyk3lEwgfUQgYN+i/lx++1Z3wZknSIp3QCKxHLyg==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.7.5.tgz",
+      "integrity": "sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==",
       "dependencies": {
         "@lit/reactive-element": "^1.6.0",
         "lit-element": "^3.3.0",
@@ -6307,9 +6355,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.3.tgz",
-      "integrity": "sha512-9DyLzcn/kbRGowz2vFmSANFbRZTxYUgYYFqzie89w6GLpPUiBCDHfcdeRUV/k3Q2ueYxNjfv46yPCtKAEAPOVw==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.7.4.tgz",
+      "integrity": "sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -6418,29 +6466,16 @@
       }
     },
     "node_modules/motion": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/motion/-/motion-10.15.5.tgz",
-      "integrity": "sha512-ejP6KioN4pigTGxL93APzOnvtLklParL59UQB2T3HWXQBxFcIp5/7YXFmkgiA6pNKKzjvnLhnonRBN5iSFMnNw==",
+      "version": "10.16.2",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-10.16.2.tgz",
+      "integrity": "sha512-p+PurYqfUdcJZvtnmAqu5fJgV2kR0uLFQuBKtLeFVTrYEVllI99tiOTSefVNYuip9ELTEkepIIDftNdze76NAQ==",
       "dependencies": {
         "@motionone/animation": "^10.15.1",
-        "@motionone/dom": "^10.15.5",
-        "@motionone/svelte": "^10.15.5",
+        "@motionone/dom": "^10.16.2",
+        "@motionone/svelte": "^10.16.2",
         "@motionone/types": "^10.15.1",
         "@motionone/utils": "^10.15.1",
-        "@motionone/vue": "^10.15.5"
-      }
-    },
-    "node_modules/motion/node_modules/@motionone/dom": {
-      "version": "10.15.5",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.15.5.tgz",
-      "integrity": "sha512-Xc5avlgyh3xukU9tydh9+8mB8+2zAq+WlLsC3eEIp7Ax7DnXgY7Bj/iv0a4X2R9z9ZFZiaXK3BO0xMYHKbAAdA==",
-      "dependencies": {
-        "@motionone/animation": "^10.15.1",
-        "@motionone/generators": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
+        "@motionone/vue": "^10.16.2"
       }
     },
     "node_modules/ms": {
@@ -6490,9 +6525,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6751,9 +6786,9 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.13.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.13.2.tgz",
-      "integrity": "sha512-q44QFLhOhty2Bd0Y46fnYW0gD/cbVM9dUVtNTDKPcdXSMA7jfY+Jpd6rk3GB0lcQss0z5s/6CmVP0Z/hV+g6pw==",
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.15.1.tgz",
+      "integrity": "sha512-qs2ansoQEwzNiV5eAcRT1p1EC/dmEzaATVDJNiB3g2sRDWdA7b7MurXdJjB2+/WQktGWZwxvDrnuRFbWuIr64g==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -6775,9 +6810,9 @@
       }
     },
     "node_modules/proxy-compare": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.0.tgz",
-      "integrity": "sha512-f1us0OsVAJ3tdIMXGQx2lmseYS4YXe4W+sKF5g5ww/jV+5ogMadPt+sIZ+88Ga9kvMJsrRNWzCrKPpr6pMWYbA=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.5.1.tgz",
+      "integrity": "sha512-oyfc0Tx87Cpwva5ZXezSp5V9vht1c7dZBhvuV/y3ctkgMVUmiAGDVeeB0dKhGSyT0v1ZTEQYpe/RXlBVBNuCLA=="
     },
     "node_modules/qrcode": {
       "version": "1.5.0",
@@ -6797,9 +6832,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
-      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
+      "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -7503,15 +7538,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
+      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uint8arrays": {
@@ -7661,11 +7696,11 @@
       }
     },
     "node_modules/valtio": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.4.tgz",
-      "integrity": "sha512-gqGWh0DjtDMAy8Jaui8ufFoxlQB1k1NiA/QHrpKoTUk9EeY331WKeYhvtGn1u703RcefrDCez7PT+qeCu9lWEw==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.10.6.tgz",
+      "integrity": "sha512-SxN1bHUmdhW6V8qsQTpCgJEwp7uHbntuH0S9cdLQtiohuevwBksbpXjwj5uDMA7bLwg1WKyq9sEpZrx3TIMrkA==",
       "dependencies": {
-        "proxy-compare": "2.5.0",
+        "proxy-compare": "2.5.1",
         "use-sync-external-store": "1.2.0"
       },
       "engines": {
@@ -7676,6 +7711,45 @@
       },
       "peerDependenciesMeta": {
         "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.0.7.tgz",
+      "integrity": "sha512-P/T2Zn8+V74kxO2e2NdhNR/MBtldovssigvc36+7g3DgTeETKnSS1fMQdBl0jE+Atlal+M6cuJ2HcFY7U45o0Q==",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.9.0",
+        "@noble/curves": "1.0.0",
+        "@noble/hashes": "1.3.0",
+        "@scure/bip32": "1.3.0",
+        "@scure/bip39": "1.2.0",
+        "@wagmi/chains": "1.1.0",
+        "abitype": "0.8.7",
+        "isomorphic-ws": "5.0.0",
+        "ws": "8.12.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      }
+    },
+    "node_modules/viem/node_modules/ws": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -7751,9 +7825,9 @@
       }
     },
     "node_modules/wagmi": {
-      "version": "0.12.12",
-      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-0.12.12.tgz",
-      "integrity": "sha512-AEY4res9WCeAEbVv++tgdx6981lkdiAwfpLPj24mawMoocj2Cqr6j304lq7EJiEhnoiPqIwvbBzme3sAmUWYUA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-1.2.2.tgz",
+      "integrity": "sha512-HSqxb/Dejx0kSvGIxZKy3WzPFVHaG7FC0X8O3c2bq7Y+dP4gR8TIOKjywNzvE4eL1wg9xcTgAbiLedrFWwCERg==",
       "funding": [
         {
           "type": "gitcoin",
@@ -7768,14 +7842,14 @@
         "@tanstack/query-sync-storage-persister": "^4.27.1",
         "@tanstack/react-query": "^4.28.0",
         "@tanstack/react-query-persist-client": "^4.28.0",
-        "@wagmi/core": "0.10.10",
-        "abitype": "^0.3.0",
+        "@wagmi/core": "1.2.2",
+        "abitype": "0.8.7",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
-        "ethers": ">=5.5.1 <6",
         "react": ">=17.0.0",
-        "typescript": ">=4.9.4"
+        "typescript": ">=5.0.4",
+        "viem": ">=0.3.35"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -7986,9 +8060,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.7.tgz",
-      "integrity": "sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.3.8.tgz",
+      "integrity": "sha512-4h28KCkHg5ii/wcFFJ5Fp+k1J3gJoasaIbppdgZFO4BPJnsNxL0mQXBSFgOgAdCdBj35aDTPvdAJReTMntFPGg==",
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },

--- a/garage/package.json
+++ b/garage/package.json
@@ -13,7 +13,7 @@
     "@chakra-ui/react": "^2.3.4",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@rainbow-me/rainbowkit": "^0.12.12",
+    "@rainbow-me/rainbowkit": "^1.0.3",
     "@tableland/rigs": "^0.3.0",
     "@tableland/sdk": "^4.3.2",
     "alchemy-sdk": "^2.8.3",
@@ -26,13 +26,14 @@
     "react-dom": "^18.2.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.4.3",
-    "wagmi": "^0.12.12"
+    "viem": "~1.0.6",
+    "wagmi": "~1.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.0.38",
     "@types/react-dom": "^18.2.1",
     "@vitejs/plugin-react": "^3.1.0",
-    "typescript": "^4.6.4",
+    "typescript": "^5.1.3",
     "vite": "^4.3.2",
     "vite-plugin-ejs": "^1.6.4",
     "vite-plugin-svgr": "^2.4.0"

--- a/garage/src/App.tsx
+++ b/garage/src/App.tsx
@@ -12,7 +12,7 @@ import {
   RainbowKitProvider,
   darkTheme,
 } from "@rainbow-me/rainbowkit";
-import { configureChains, createClient, WagmiConfig } from "wagmi";
+import { configureChains, createConfig, WagmiConfig } from "wagmi";
 import { alchemyProvider } from "wagmi/providers/alchemy";
 import { publicProvider } from "wagmi/providers/public";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -25,7 +25,7 @@ import { ActingAsAddressContextProvider } from "./components/ActingAsAddressCont
 import { routes } from "./routes";
 import { chain } from "./env";
 
-const { chains, provider } = configureChains(
+const { chains, publicClient } = configureChains(
   [chain],
   [
     alchemyProvider({ apiKey: import.meta.env.VITE_ALCHEMY_ID }),
@@ -36,12 +36,13 @@ const { chains, provider } = configureChains(
 const { connectors } = getDefaultWallets({
   appName: "Tableland Garage",
   chains,
+  projectId: import.meta.env.VITE_WALLET_CONNECT_PROJECT_ID ?? "",
 });
 
-const wagmiClient = createClient({
+const wagmiClient = createConfig({
   autoConnect: true,
   connectors,
-  provider,
+  publicClient,
 });
 
 const colors = {
@@ -197,7 +198,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ChakraProvider theme={theme}>
-        <WagmiConfig client={wagmiClient}>
+        <WagmiConfig config={wagmiClient}>
           <RainbowKitProvider chains={chains} theme={darkTheme()}>
             <ActingAsAddressContextProvider>
               <RigAttributeStatsContextProvider>

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -80,7 +80,7 @@ export const TrainRigsModal = ({
     address: as0xString(contractAddress),
     abi,
     functionName: "trainRig",
-    args: [rigs.map((rig) => ethers.BigNumber.from(rig.id))],
+    args: [rigs.map((rig) => BigInt(rig.id))],
     enabled: isOpen,
   });
 
@@ -155,7 +155,7 @@ export const ParkRigsModal = ({
     address: as0xString(contractAddress),
     abi,
     functionName: "parkRig",
-    args: [rigs.map((rig) => ethers.BigNumber.from(rig.id))],
+    args: [rigs.map((rig) => BigInt(rig.id))],
     enabled: isOpen,
   });
 
@@ -227,7 +227,7 @@ interface PilotTransactionProps {
 
 const toContractArgs = (
   pairs: { rig: Rig; pilot: NFT }[]
-): [ethers.BigNumber[], WalletAddress[], ethers.BigNumber[]] => {
+): [bigint[], WalletAddress[], bigint[]] => {
   const validPairs = pairs
     .map(({ pilot, ...rest }) => {
       if (isValidAddress(pilot.contract)) {
@@ -242,9 +242,9 @@ const toContractArgs = (
     .filter(isPresent);
 
   return [
-    validPairs.map(({ rig }) => ethers.BigNumber.from(rig.id)),
+    validPairs.map(({ rig }) => BigInt(rig.id)),
     validPairs.map(({ pilotContract }) => pilotContract),
-    validPairs.map(({ pilotTokenId }) => ethers.BigNumber.from(pilotTokenId)),
+    validPairs.map(({ pilotTokenId }) => BigInt(pilotTokenId)),
   ];
 };
 
@@ -544,11 +544,10 @@ const PickRigPilotStep = ({
 
   const [currentRig, setCurrentRig] = useState(0);
   const rig = useMemo(() => rigs[currentRig], [rigs, currentRig]);
-  const pilot = useMemo(() => pilots[rigs[currentRig].id], [
-    pilots,
-    rigs,
-    currentRig,
-  ]);
+  const pilot = useMemo(
+    () => pilots[rigs[currentRig].id],
+    [pilots, rigs, currentRig]
+  );
 
   const next = useCallback(() => {
     setCurrentRig((old) => {

--- a/garage/src/components/TransactionStateAlert.tsx
+++ b/garage/src/components/TransactionStateAlert.tsx
@@ -36,8 +36,8 @@ export const TransactionStateAlert = (props: TransactionStateAlertProps) => {
   const blockExplorerLink = `${blockExplorerBaseUrl}/tx/${data?.hash}`;
   const hasReceipt = !!waitData;
 
-  const isSuccess = hasReceipt ? waitData.status === 1 : false;
-  const isError = hasReceipt ? waitData.status === 0 : false;
+  const isSuccess = hasReceipt ? waitData.status === "success" : false;
+  const isError = hasReceipt ? waitData.status === "reverted" : false;
 
   const status =
     transactionLoading || waitLoading

--- a/garage/src/components/TransferRigModal.tsx
+++ b/garage/src/components/TransferRigModal.tsx
@@ -60,7 +60,7 @@ export const TransferRigModal = ({
       : "safeTransferFrom",
     args:
       address && isValidToAddress && isValidAddress(toAddress)
-        ? [address, toAddress, ethers.BigNumber.from(rig.id)]
+        ? [address, toAddress, BigInt(rig.id)]
         : undefined,
     enabled: isOpen && isValidToAddress,
   });

--- a/garage/src/hooks/useSigner.ts
+++ b/garage/src/hooks/useSigner.ts
@@ -1,0 +1,26 @@
+// Convert wagmi/viem `WalletClient` to ethers `Signer`
+import * as React from "react";
+import { type WalletClient, useWalletClient } from "wagmi";
+import { providers, type Signer } from "ethers";
+
+export function walletClientToSigner(walletClient: WalletClient): Signer {
+  const { account, chain, transport } = walletClient;
+  const network = {
+    chainId: chain.id,
+    name: chain.name,
+    ensAddress: chain.contracts?.ensRegistry?.address,
+  };
+  const provider = new providers.Web3Provider(transport, network);
+  const signer = provider.getSigner(account.address);
+  return signer;
+}
+
+export function useSigner({ chainId }: { chainId?: number } = {}):
+  | Signer
+  | undefined {
+  const { data: walletClient } = useWalletClient({ chainId });
+  return React.useMemo(
+    () => (walletClient ? walletClientToSigner(walletClient) : undefined),
+    [walletClient]
+  );
+}

--- a/garage/src/hooks/useTablelandConnection.ts
+++ b/garage/src/hooks/useTablelandConnection.ts
@@ -1,7 +1,7 @@
-import { Database, Validator } from "@tableland/sdk";
+import { Database, Validator, helpers } from "@tableland/sdk";
 import { chain } from "../env";
 
-const db = Database.readOnly(chain.id);
+const db = new Database({ baseUrl: helpers.getBaseUrl(chain.id) });
 const validator = new Validator(db.config);
 const data = { db, validator };
 

--- a/garage/src/pages/Admin/index.tsx
+++ b/garage/src/pages/Admin/index.tsx
@@ -15,7 +15,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { Database } from "@tableland/sdk";
-import { useSigner } from "wagmi";
+import { useSigner } from "../../hooks/useSigner";
 import { TOPBAR_HEIGHT } from "../../Topbar";
 import { Footer } from "../../components/Footer";
 import { isValidAddress } from "../../utils/types";
@@ -34,7 +34,7 @@ const MODULE_PROPS = {
 const GiveFtRewardForm = (props: React.ComponentProps<typeof Box>) => {
   const toast = useToast();
 
-  const { data: signer } = useSigner();
+  const signer = useSigner();
 
   const db = useMemo(() => {
     if (signer) return new Database({ signer });

--- a/garage/src/pages/Dashboard/modules/RigsInventory.tsx
+++ b/garage/src/pages/Dashboard/modules/RigsInventory.tsx
@@ -219,8 +219,11 @@ export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
     }
   }, [pendingTx, refreshRigsAndClearPendingTx, validator, clearPendingTx]);
 
-  const { trainRigsModal, pilotRigsModal, parkRigsModal } =
-    useGlobalFlyParkModals();
+  const {
+    trainRigsModal,
+    pilotRigsModal,
+    parkRigsModal,
+  } = useGlobalFlyParkModals();
 
   const openTrainModal = useCallback(() => {
     if (rigs?.length && selectedRigs.size) {

--- a/garage/src/pages/Dashboard/modules/RigsInventory.tsx
+++ b/garage/src/pages/Dashboard/modules/RigsInventory.tsx
@@ -219,11 +219,8 @@ export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
     }
   }, [pendingTx, refreshRigsAndClearPendingTx, validator, clearPendingTx]);
 
-  const {
-    trainRigsModal,
-    pilotRigsModal,
-    parkRigsModal,
-  } = useGlobalFlyParkModals();
+  const { trainRigsModal, pilotRigsModal, parkRigsModal } =
+    useGlobalFlyParkModals();
 
   const openTrainModal = useCallback(() => {
     if (rigs?.length && selectedRigs.size) {
@@ -291,7 +288,7 @@ export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
                 selected={selected}
                 selectable={!pendingTx && selectable}
                 toggleSelected={() => toggleRigSelected(rig)}
-                currentBlockNumber={currentBlockNumber}
+                currentBlockNumber={Number(currentBlockNumber)}
               />
             );
           })}

--- a/garage/src/pages/PilotDetails/index.tsx
+++ b/garage/src/pages/PilotDetails/index.tsx
@@ -21,7 +21,6 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import { useParams, Link as RouterLink } from "react-router-dom";
-import { ethers } from "ethers";
 import { useAccount, useBlockNumber, useContractRead, useEnsName } from "wagmi";
 import { RoundSvgIcon } from "../../components/RoundSvgIcon";
 import { useTablelandConnection } from "../../hooks/useTablelandConnection";
@@ -206,7 +205,7 @@ export const PilotDetails = () => {
     address: as0xString(collection),
     abi,
     functionName: "ownerOf",
-    args: [ethers.BigNumber.from(id)],
+    args: [BigInt(String(id))],
   });
 
   const { address } = useAccount();
@@ -247,7 +246,7 @@ export const PilotDetails = () => {
         width="100%"
         height="100%"
       >
-        {pilot && events && currentBlockNumber && (
+        {pilot && events && Number(currentBlockNumber) && (
           <>
             <GridItem>
               <VStack align="stretch" spacing={GRID_GAP}>
@@ -258,7 +257,7 @@ export const PilotDetails = () => {
                     owner={owner}
                     userOwnsNFT={userOwnsNFT}
                     events={events}
-                    currentBlockNumber={currentBlockNumber}
+                    currentBlockNumber={Number(currentBlockNumber)}
                   />
                 </Show>
                 <Box p={4} bgColor="paper" borderRadius="3px" flexGrow="1">
@@ -275,13 +274,13 @@ export const PilotDetails = () => {
                     owner={owner}
                     userOwnsNFT={userOwnsNFT}
                     events={events}
-                    currentBlockNumber={currentBlockNumber}
+                    currentBlockNumber={Number(currentBlockNumber)}
                   />
                 </Show>
                 <FlightLog
                   pilot={pilot}
                   events={events}
-                  currentBlockNumber={currentBlockNumber}
+                  currentBlockNumber={Number(currentBlockNumber)}
                   {...MODULE_PROPS}
                 />
               </VStack>

--- a/garage/src/pages/PilotDetails/index.tsx
+++ b/garage/src/pages/PilotDetails/index.tsx
@@ -205,7 +205,7 @@ export const PilotDetails = () => {
     address: as0xString(collection),
     abi,
     functionName: "ownerOf",
-    args: [BigInt(String(id))],
+    args: [BigInt(id ?? "")],
   });
 
   const { address } = useAccount();

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -162,6 +162,7 @@ export const RigDetails = () => {
   const { validator } = useTablelandConnection();
 
   const { data: contractData, refetch } = useContractReads({
+    allowFailure: false,
     contracts: [
       {
         address: as0xString(contractAddress),
@@ -285,8 +286,8 @@ export const RigDetails = () => {
                   <RigHeader
                     {...MODULE_PROPS}
                     rig={rig}
-                    owner={(owner as any)?.result}
-                    tokenURI={(tokenURI as any)?.result}
+                    owner={owner}
+                    tokenURI={tokenURI}
                     userOwnsRig={userOwnsRig}
                     currentBlockNumber={Number(currentBlockNumber)}
                     refresh={refresh}
@@ -313,8 +314,8 @@ export const RigDetails = () => {
                   <RigHeader
                     {...MODULE_PROPS}
                     rig={rig}
-                    owner={(owner as any)?.result}
-                    tokenURI={(tokenURI as any)?.result}
+                    owner={owner}
+                    tokenURI={tokenURI}
                     userOwnsRig={userOwnsRig}
                     currentBlockNumber={Number(currentBlockNumber)}
                     refresh={refresh}
@@ -327,7 +328,7 @@ export const RigDetails = () => {
                   onOpenParkModal={onOpenParkModal}
                   onOpenPilotModal={onOpenPilotModal}
                   onOpenTrainModal={onOpenTrainModal}
-                  chainPilotStatus={pilotInfo?.status === "success" ? 1 : 0}
+                  chainPilotStatus={pilotInfo?.status}
                   {...MODULE_PROPS}
                 />
                 <FlightLog rig={rig} nfts={nfts} {...MODULE_PROPS} />

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -167,19 +167,19 @@ export const RigDetails = () => {
         address: as0xString(contractAddress),
         abi,
         functionName: "ownerOf",
-        args: [ethers.BigNumber.from(id)],
+        args: [BigInt(String(id))],
       },
       {
         address: as0xString(contractAddress),
         abi,
         functionName: "tokenURI",
-        args: [ethers.BigNumber.from(id)],
+        args: [BigInt(String(id))],
       },
       {
         address: as0xString(contractAddress),
         abi,
         functionName: "pilotInfo",
-        args: [ethers.BigNumber.from(id)],
+        args: [BigInt(String(id))],
       },
     ],
   });
@@ -199,7 +199,8 @@ export const RigDetails = () => {
   const userOwnsRig = useMemo(() => {
     return (
       !!actingAsAddress &&
-      actingAsAddress.toLowerCase() === owner?.toLowerCase()
+      actingAsAddress.toLowerCase() ===
+        ((owner as any)?.toLowerCase() as string)
     );
   }, [actingAsAddress, owner]);
 
@@ -244,11 +245,8 @@ export const RigDetails = () => {
   const currentNFT =
     rig?.currentPilot && nfts && findNFT(rig.currentPilot, nfts);
 
-  const {
-    trainRigsModal,
-    pilotRigsModal,
-    parkRigsModal,
-  } = useGlobalFlyParkModals();
+  const { trainRigsModal, pilotRigsModal, parkRigsModal } =
+    useGlobalFlyParkModals();
 
   const onOpenTrainModal = useCallback(() => {
     if (rig) trainRigsModal.openModal([rig], setPendingTx);
@@ -287,10 +285,10 @@ export const RigDetails = () => {
                   <RigHeader
                     {...MODULE_PROPS}
                     rig={rig}
-                    owner={owner}
-                    tokenURI={tokenURI}
+                    owner={(owner as any)?.result}
+                    tokenURI={(tokenURI as any)?.result}
                     userOwnsRig={userOwnsRig}
-                    currentBlockNumber={currentBlockNumber}
+                    currentBlockNumber={Number(currentBlockNumber)}
                     refresh={refresh}
                   />
                 </Show>
@@ -315,10 +313,10 @@ export const RigDetails = () => {
                   <RigHeader
                     {...MODULE_PROPS}
                     rig={rig}
-                    owner={owner}
-                    tokenURI={tokenURI}
+                    owner={(owner as any)?.result}
+                    tokenURI={(tokenURI as any)?.result}
                     userOwnsRig={userOwnsRig}
-                    currentBlockNumber={currentBlockNumber}
+                    currentBlockNumber={Number(currentBlockNumber)}
                     refresh={refresh}
                   />
                 </Show>
@@ -329,7 +327,7 @@ export const RigDetails = () => {
                   onOpenParkModal={onOpenParkModal}
                   onOpenPilotModal={onOpenPilotModal}
                   onOpenTrainModal={onOpenTrainModal}
-                  chainPilotStatus={pilotInfo?.status}
+                  chainPilotStatus={pilotInfo?.status === "success" ? 1 : 0}
                   {...MODULE_PROPS}
                 />
                 <FlightLog rig={rig} nfts={nfts} {...MODULE_PROPS} />

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -199,8 +199,7 @@ export const RigDetails = () => {
   const userOwnsRig = useMemo(() => {
     return (
       !!actingAsAddress &&
-      actingAsAddress.toLowerCase() ===
-        ((owner as any)?.toLowerCase() as string)
+      actingAsAddress.toLowerCase() === owner?.toLowerCase()
     );
   }, [actingAsAddress, owner]);
 

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -167,19 +167,19 @@ export const RigDetails = () => {
         address: as0xString(contractAddress),
         abi,
         functionName: "ownerOf",
-        args: [BigInt(String(id))],
+        args: [BigInt(id ?? "")],
       },
       {
         address: as0xString(contractAddress),
         abi,
         functionName: "tokenURI",
-        args: [BigInt(String(id))],
+        args: [BigInt(id ?? "")],
       },
       {
         address: as0xString(contractAddress),
         abi,
         functionName: "pilotInfo",
-        args: [BigInt(String(id))],
+        args: [BigInt(id ?? "")],
       },
     ],
   });

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -14,7 +14,6 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react";
-import { ethers } from "ethers";
 import { ArrowForwardIcon } from "@chakra-ui/icons";
 import { useParams, Link as RouterLink } from "react-router-dom";
 import { useBlockNumber, useContractReads, useEnsName } from "wagmi";

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -244,8 +244,11 @@ export const RigDetails = () => {
   const currentNFT =
     rig?.currentPilot && nfts && findNFT(rig.currentPilot, nfts);
 
-  const { trainRigsModal, pilotRigsModal, parkRigsModal } =
-    useGlobalFlyParkModals();
+  const {
+    trainRigsModal,
+    pilotRigsModal,
+    parkRigsModal,
+  } = useGlobalFlyParkModals();
 
   const onOpenTrainModal = useCallback(() => {
     if (rig) trainRigsModal.openModal([rig], setPendingTx);

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -165,19 +165,19 @@ export const RigDetails = () => {
     allowFailure: false,
     contracts: [
       {
-        address: as0xString(contractAddress),
+        address: as0xString(contractAddress)!,
         abi,
         functionName: "ownerOf",
         args: [BigInt(id ?? "")],
       },
       {
-        address: as0xString(contractAddress),
+        address: as0xString(contractAddress)!,
         abi,
         functionName: "tokenURI",
         args: [BigInt(id ?? "")],
       },
       {
-        address: as0xString(contractAddress),
+        address: as0xString(contractAddress)!,
         abi,
         functionName: "pilotInfo",
         args: [BigInt(id ?? "")],

--- a/garage/src/pages/RigDetails/modules/Pilots.tsx
+++ b/garage/src/pages/RigDetails/modules/Pilots.tsx
@@ -92,7 +92,7 @@ export const Pilots = ({
   useEffect(() => {
     refetch();
   }, [rig, refetch]);
-  const pilots = getPilots(rig, nfts, blockNumber);
+  const pilots = getPilots(rig, nfts, Number(blockNumber));
 
   const {
     isOpen: isInfoOpen,
@@ -192,7 +192,7 @@ export const Pilots = ({
       {isOwner && (
         <StackItem px={4}>
           <HStack gap={3}>
-            {!rig.currentPilot && (!rig.isTrained && chainPilotStatus !== 2) && (
+            {!rig.currentPilot && !rig.isTrained && chainPilotStatus !== 2 && (
               <ChainAwareButton
                 variant="outlined"
                 onClick={onOpenTrainModal}


### PR DESCRIPTION
With `wagmi` moving from `ethers` to `viem`, the `useSigner` hook no longer works. Thus, a custom hook has been created, along with other minor changes due to the dep bump/migration. Also, WalletConnect now requires an API key—it's a `projectId` variable used in the `wagmi` setup and is now accessible as `VITE_WALLET_CONNECT_PROJECT_ID` (env var); this has been added within Vercel as well.