### PR TITLE
Garage: fix filecoin modal overflow

### DIFF
--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -208,7 +208,7 @@ const FilecoinDealsModal = ({
   onClose,
 }: FilecoinDealsModalProps) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size="xl">
+    <Modal isOpen={isOpen} onClose={onClose} size="3xl">
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>Filecoin Deal Information</ModalHeader>
@@ -220,17 +220,30 @@ const FilecoinDealsModal = ({
           <Table>
             <Thead>
               <Tr>
-                <Th>Deal ID</Th>
+                <Th width="80px">Deal ID</Th>
                 <Th>Deal Selector</Th>
-                <Th>Deal link</Th>
+                <Th width="90px" isNumeric>
+                  Deal link
+                </Th>
               </Tr>
             </Thead>
             <Tbody>
               {rig.filecoinDeals.map(({ dealId, selector }) => (
                 <Tr key={`deal-${dealId}`}>
-                  <Td>{dealId}</Td>
-                  <Td>{selector}</Td>
-                  <Td isNumeric>
+                  <Td width="80px">{dealId}</Td>
+                  <Td
+                    width="auto"
+                    sx={{
+                      maxWidth: { base: "160px", md: "300px" },
+                      textOverflow: "ellipsis",
+                      overflow: "hidden",
+                      whiteSpace: "nowrap",
+                    }}
+                    title={selector}
+                  >
+                    {selector}
+                  </Td>
+                  <Td width="90px" isNumeric>
                     <Link
                       href={`https://filfox.info/deal/${dealId}`}
                       isExternal
@@ -343,8 +356,11 @@ export const RigDetails = () => {
   const currentNFT =
     rig?.currentPilot && nfts && findNFT(rig.currentPilot, nfts);
 
-  const { trainRigsModal, pilotRigsModal, parkRigsModal } =
-    useGlobalFlyParkModals();
+  const {
+    trainRigsModal,
+    pilotRigsModal,
+    parkRigsModal,
+  } = useGlobalFlyParkModals();
 
   const onOpenTrainModal = useCallback(() => {
     if (rig) trainRigsModal.openModal([rig], setPendingTx);


### PR DESCRIPTION
The selector text has a tooltip (`title` attr) so that you can hover over it and see the full value if it is truncated

<img width="1271" alt="image" src="https://github.com/tablelandnetwork/rigs/assets/656107/bc1f2ddf-793f-4c10-9287-4b67cc692e75">
<img width="674" alt="image" src="https://github.com/tablelandnetwork/rigs/assets/656107/f465dfc5-dd1c-49d1-9731-49258cfd0546">
<img width="550" alt="image" src="https://github.com/tablelandnetwork/rigs/assets/656107/505ccb7c-21f1-401a-8b20-364391fe90fc">

