### PR TITLE
Add edge function that checks if a wallets earned ft is in a given range

### DIFF
--- a/garage/api/ft/[from]/[to]/index.ts
+++ b/garage/api/ft/[from]/[to]/index.ts
@@ -1,0 +1,46 @@
+import { deployments } from "@tableland/rigs/deployments";
+
+export const config = { runtime: "edge" };
+
+const { pilotSessionsTable, ftRewardsTable } = deployments.ethereum;
+
+const getFtQuery = (address: string) => {
+  return `
+    SELECT SUM(ft) as "ft"
+    FROM (
+      SELECT (coalesce(end_time, BLOCK_NUM(1)) - start_time) as "ft" FROM ${pilotSessionsTable} WHERE lower(owner) = lower('${address}')
+      UNION ALL
+      SELECT amount as "ft" FROM ${ftRewardsTable} WHERE lower(recipient) = lower('${address}')
+    )`;
+};
+
+export default async function (request: Request) {
+  if (request.method !== "POST") return new Response(null, { status: 405 });
+
+  const url = new URL(request.url);
+  const { from, to } = Object.fromEntries(url.searchParams);
+  const min = parseInt(from, 10);
+  const max = parseInt(to, 10);
+
+  if (isNaN(min)) return new Response(null, { status: 400 });
+
+  const { wallet } = await request.json();
+
+  const query = getFtQuery(wallet);
+  const apiUrl = new URL("https://tableland.network/api/v1/query");
+  apiUrl.searchParams.set("statement", query);
+  apiUrl.searchParams.set("unwrap", "true");
+
+  const result = await fetch(apiUrl.toString());
+  const { ft } = await result.json();
+
+  if (!ft) {
+    return new Response(null, { status: 404 });
+  }
+
+  const success = ft >= min && (isNaN(max) || ft < max);
+
+  return new Response(JSON.stringify({ success }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/garage/vercel.json
+++ b/garage/vercel.json
@@ -1,5 +1,10 @@
 {
   "trailingSlash": false,
-  "rewrites": [{ "source": "/(.*)", "destination": "/" }],
+  "rewrites": [
+    {
+      "source": "/:path((?!api/).*)",
+      "destination": "/"
+    }
+  ],
   "github": { "silent": true }
 }


### PR DESCRIPTION
Adds a vercel edge function that checks if the amount of FT a wallet has earned is in a given range. The function input/output follows the format of [Vulcan Custom Webhooks](https://help.vulcan.xyz/custom-webhook) so that we can use Vulcan to assign discord roles based on the amount of FT a wallet has earned. The function accepts a range `[from, to)` in the path and expects a JSON-body of `{ "wallet": "<addr>" }`, and returns true if the wallets total FT earned is in that range. This makes it easy to setup multiple different FT-roles in Vulcan so that each user only gest the highest tier role that they qualify for (which makes it clearner imo). I ended up using the gateway api instead of the sdk to make the function startup time faster, based on some local testing it ~25-30% faster to not load the sdk. 

Example URLs (won't work until the PR is deployed to master):

Checks if a wallet has earned `1_000_000 <= ft < 5_000_000`
https://garage.tableland.xyz/api/ft/1000000/5000000

Checks if a wallet has earned  `5_000_000 <= ft < 10_000_000`
https://garage.tableland.xyz/api/ft/5000000/10000000

Checks if a wallet has earned `ft >= 10_000_000`
https://garage.tableland.xyz/api/ft/10000000/inf
(note that the second path argument is required)

(If we want to use stacking roles instead so that a user gets a role for every tier they qualify for instead of just the highest tier we can just set the `to` param to `inf` for all urls.)

Closes RIG-16

Example curls to the function using the preview deployment for my wallet that has ~10.5M FT

In range `[10M, 15M)` (true)
```
curl -X POST https://rigs-garage-n4zb18kmr-tableland.vercel.app/api/ft/10000000/15000000 \
  -H 'Content-Type: application/json' \
  -d '{ "wallet": "0x3c8a3fc1da41295888e83656a6f1bbb11c1dbb8c" }'
```

In range `[500k, 10M)` (false)
```
curl -X POST https://rigs-garage-n4zb18kmr-tableland.vercel.app/api/ft/500000/10000000 \
  -H 'Content-Type: application/json' \
  -d '{ "wallet": "0x3c8a3fc1da41295888e83656a6f1bbb11c1dbb8c" }'
```

In range `[10M, inf)` (true)
```
curl -X POST https://rigs-garage-n4zb18kmr-tableland.vercel.app/api/ft/10000000/inf \
  -H 'Content-Type: application/json' \
  -d '{ "wallet": "0x3c8a3fc1da41295888e83656a6f1bbb11c1dbb8c" }'
```