### PR TITLE
Garage: fix secondary chain for prod environment

### DIFF
--- a/garage/src/env.ts
+++ b/garage/src/env.ts
@@ -33,7 +33,7 @@ const mainChainEnvMapping = {
 const secondaryChainEnvMapping = {
   [DeploymentEnvironment.DEVELOPMENT]: chains.polygonMumbai,
   [DeploymentEnvironment.STAGING]: chains.polygonMumbai,
-  [DeploymentEnvironment.PRODUCTION]: chains.filecoin,
+  [DeploymentEnvironment.PRODUCTION]: chains.arbitrum,
 };
 
 // Main chain used by the rigs contract


### PR DESCRIPTION
The voting contract & ft rewards table is deployed to arbitrum and not filecoin!

Note: this PR is targeting main and not staging, I figured we might as well deploy this right away? And I don't think we have merged anything to staging yet so it would be easy to recreate staging again after this is merged, but feel free to change base to staging as well if you think that is better