### PR TITLE
Garage: update admin page to check admin permissions

### DIFF
--- a/garage/src/abis/VotingRegistry.ts
+++ b/garage/src/abis/VotingRegistry.ts
@@ -76,4 +76,28 @@ export const abi = [
     stateMutability: "nonpayable",
     type: "function",
   },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "role",
+        type: "bytes32",
+      },
+      {
+        internalType: "address",
+        name: "account",
+        type: "address",
+      },
+    ],
+    name: "hasRole",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
 ] as const;

--- a/garage/src/hooks/useIsAdmin.ts
+++ b/garage/src/hooks/useIsAdmin.ts
@@ -1,0 +1,44 @@
+import { useContractReads } from "wagmi";
+import { as0xString } from "../utils/types";
+import { secondaryChain, deployment } from "../env";
+import { abi as missionsAbi } from "../abis/MissionsManager";
+import { abi as votingAbi } from "../abis/VotingRegistry";
+import { useAccount } from "./useAccount";
+
+const { votingContractAddress, missionContractAddress } = deployment;
+
+const ZERO_ADDR = "0x0000000000000000000000000000000000000000" as const;
+
+const MISSIONS_ADMIN_ROLE =
+  "0x6de1decd3455ea3e945a8b81428c6da1e39da9f747dff73b900c35f95d8d9528" as const;
+const VOTING_ADMIN_ROLE =
+  "0x26e5e0c1d827967646b29471a0f5eef941c85bdbb97c194dc3fa6291a994a148" as const;
+
+export const useIsAdmin = () => {
+  const { address } = useAccount();
+
+  const { isLoading, data } = useContractReads({
+    allowFailure: false,
+    enabled: !!address,
+    contracts: [
+      {
+        chainId: secondaryChain.id,
+        address: as0xString(votingContractAddress)!,
+        abi: votingAbi,
+        functionName: "hasRole",
+        args: [VOTING_ADMIN_ROLE, address ?? ZERO_ADDR],
+      },
+      {
+        chainId: secondaryChain.id,
+        address: as0xString(missionContractAddress)!,
+        abi: missionsAbi,
+        functionName: "hasRole",
+        args: [MISSIONS_ADMIN_ROLE, address ?? ZERO_ADDR],
+      },
+    ],
+  });
+
+  if (!data || isLoading) return { isLoading, data: null };
+
+  return { isLoading, data: { votingAdmin: data[0], missionsAdin: data[1] } };
+};

--- a/garage/src/pages/Admin/index.tsx
+++ b/garage/src/pages/Admin/index.tsx
@@ -20,6 +20,8 @@ import {
   Th,
   Tbody,
   HStack,
+  Spinner,
+  Text,
 } from "@chakra-ui/react";
 import { Link } from "react-router-dom";
 import { Database } from "@tableland/sdk";
@@ -33,6 +35,7 @@ import { CreateProposalModal } from "../../components/CreateProposalModal";
 import { useProposals } from "../../hooks/useProposals";
 import { useAdminMisisons } from "../../hooks/useMissions";
 import { secondaryChain, deployment } from "../../env";
+import { useIsAdmin } from "../../hooks/useIsAdmin";
 
 const { ftRewardsTable } = deployment;
 
@@ -274,7 +277,24 @@ const ListMissionsForm = (props: React.ComponentProps<typeof Box>) => {
   );
 };
 
+const NoPermissionsForm = ({
+  title,
+  body,
+  ...props
+}: { title: string; body: string } & React.ComponentProps<typeof Box>) => {
+  return (
+    <Box {...props}>
+      <Heading>{title}</Heading>
+      <Text variant="emptyState" mt={4}>
+        {body}
+      </Text>
+    </Box>
+  );
+};
+
 export const Admin = () => {
+  const { isLoading, data } = useIsAdmin();
+
   return (
     <>
       <Flex
@@ -295,9 +315,31 @@ export const Admin = () => {
           minHeight={`calc(100vh - ${TOPBAR_HEIGHT})`}
         >
           <Flex direction="column" gap={GRID_GAP} align="stretch" width="100%">
-            <GiveFtRewardForm {...MODULE_PROPS} />
-            <ListProposalsForm {...MODULE_PROPS} />
-            <ListMissionsForm {...MODULE_PROPS} />
+            {isLoading || !data ? (
+              <Spinner />
+            ) : (
+              <>
+                <GiveFtRewardForm {...MODULE_PROPS} />
+                {data.votingAdmin ? (
+                  <ListProposalsForm {...MODULE_PROPS} />
+                ) : (
+                  <NoPermissionsForm
+                    title="Proposals"
+                    body="You don't have the right permissions to manage proposals."
+                    {...MODULE_PROPS}
+                  />
+                )}
+                {data.missionsAdin ? (
+                  <ListMissionsForm {...MODULE_PROPS} />
+                ) : (
+                  <NoPermissionsForm
+                    title="Missions"
+                    body="You don't have the right permissions to manage missions."
+                    {...MODULE_PROPS}
+                  />
+                )}
+              </>
+            )}
           </Flex>
         </Flex>
       </Flex>


### PR DESCRIPTION
Adds admin permission checks for proposals & missions. I don't think there is an api for checking if an account has been granted permission to write to a table using `GRANT`, so we can't check if the account can give out ft rewards.

![image](https://github.com/tablelandnetwork/rigs/assets/656107/d85b6d2c-3ae4-449b-a0a9-1e1a6c405b7c)

Closes RIG-68