### PR TITLE
Garage: make sure all chain interactions prompt user to switch to correct chain

### DIFF
--- a/garage/src/components/ChainAwareButton.tsx
+++ b/garage/src/components/ChainAwareButton.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { Button } from "@chakra-ui/react";
-import { Chain, useNetwork } from "wagmi";
+import { Chain, useNetwork, useSwitchNetwork } from "wagmi";
 import { useChainModal } from "@rainbow-me/rainbowkit";
 import { mainChain } from "~/env";
 
@@ -15,13 +15,27 @@ export const ChainAwareButton = (
     ...rest
   } = props;
   const { openChainModal } = useChainModal();
+  const { switchNetwork } = useSwitchNetwork({ chainId: expectedChain.id });
 
   let children = _children;
-  let onClick = _onClick;
-  if (!chain || chain.id !== expectedChain.id) {
+
+  const wrongChain = !chain || chain.id !== expectedChain.id;
+  if (wrongChain) {
     children = "Wrong network";
-    onClick = openChainModal;
   }
+
+  const onClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (wrongChain) {
+        if (switchNetwork) return switchNetwork();
+
+        if (openChainModal) return openChainModal();
+      }
+
+      if (_onClick) return _onClick(event);
+    },
+    [_onClick, openChainModal, switchNetwork]
+  );
 
   return (
     <Button {...rest} onClick={onClick}>

--- a/garage/src/components/CreateProposalModal.tsx
+++ b/garage/src/components/CreateProposalModal.tsx
@@ -26,9 +26,10 @@ import {
   useWaitForTransaction,
 } from "wagmi";
 import { as0xString } from "~/utils/types";
-import { deployment } from "~/env";
+import { deployment, secondaryChain } from "~/env";
 import { abi } from "~/abis/VotingRegistry";
 import { TransactionStateAlert } from "./TransactionStateAlert";
+import { ChainAwareButton } from "./ChainAwareButton";
 
 const { votingContractAddress } = deployment;
 
@@ -72,6 +73,7 @@ export const CreateProposalModal = ({
     name !== "" && startBlock > 0 && endBlock > 0 && options.length > 0;
 
   const { config } = usePrepareContractWrite({
+    chainId: secondaryChain.id,
     address: as0xString(votingContractAddress),
     abi,
     functionName: "createProposal",
@@ -292,13 +294,14 @@ export const CreateProposalModal = ({
           <TransactionStateAlert {...contractWrite} />
         </ModalBody>
         <ModalFooter>
-          <Button
+          <ChainAwareButton
+            expectedChain={secondaryChain}
             mr={3}
             onClick={() => (write ? write() : undefined)}
             isDisabled={!isValid || isLoading || isSuccess}
           >
             Create
-          </Button>
+          </ChainAwareButton>
           <Button
             variant="ghost"
             onClick={onClose}

--- a/garage/src/components/FlyParkModals.tsx
+++ b/garage/src/components/FlyParkModals.tsx
@@ -202,13 +202,14 @@ export const ParkRigsModal = ({
           <TransactionStateAlert {...contractWrite} />
         </ModalBody>
         <ModalFooter>
-          <Button
+          <ChainAwareButton
+            expectedChain={mainChain}
             mr={3}
             onClick={() => (write ? write() : undefined)}
             isDisabled={isLoading || isSuccess}
           >
             Park {pluralize("rig", rigs)}
-          </Button>
+          </ChainAwareButton>
           <Button
             variant="ghost"
             isDisabled={isLoading || (isSuccess && isTxLoading)}

--- a/garage/src/components/SubmitMissionModal.tsx
+++ b/garage/src/components/SubmitMissionModal.tsx
@@ -24,6 +24,7 @@ import { secondaryChain, deployment } from "~/env";
 import { abi } from "~/abis/MissionsManager";
 import { useWaitForTablelandTxn } from "~/hooks/useWaitForTablelandTxn";
 import { TransactionStateAlert } from "./TransactionStateAlert";
+import { ChainAwareButton } from "./ChainAwareButton";
 
 const { missionContractAddress } = deployment;
 
@@ -139,13 +140,14 @@ export const SubmitMissionModal = ({
           <TransactionStateAlert {...contractWrite} />
         </ModalBody>
         <ModalFooter>
-          <Button
+          <ChainAwareButton
+            expectedChain={secondaryChain}
             mr={3}
             onClick={() => (write ? write() : undefined)}
             isDisabled={!isValid || isLoading || isSuccess}
           >
             Submit
-          </Button>
+          </ChainAwareButton>
           <Button
             variant="ghost"
             onClick={onClose}

--- a/garage/src/pages/Proposal/index.tsx
+++ b/garage/src/pages/Proposal/index.tsx
@@ -50,6 +50,7 @@ import { ProposalWithOptions, ProposalStatus } from "~/types";
 import { deployment, secondaryChain } from "~/env";
 import { abi } from "~/abis/VotingRegistry";
 import { useWaitForTablelandTxn } from "~/hooks/useWaitForTablelandTxn";
+import { ChainAwareButton } from "~/components/ChainAwareButton";
 
 const ipfsGatewayBaseUrl = "https://nftstorage.link";
 
@@ -272,7 +273,8 @@ const CastVote = ({
             {weightSum}%.
           </Alert>
         )}
-        <Button
+        <ChainAwareButton
+          expectedChain={secondaryChain}
           mt={2}
           isDisabled={
             status !== ProposalStatus.Open ||
@@ -285,7 +287,7 @@ const CastVote = ({
           width="100%"
         >
           {userHasVoted ? "Update Vote" : "Vote"}
-        </Button>
+        </ChainAwareButton>
       </Box>
     </VStack>
   );


### PR DESCRIPTION
Fixes an issue where the garage would fail silently if the user was connected to the 'wrong' chain instead of prompting the user to switch chain for certain interactions like submitting a MB contribution