### PR TITLE
Garage: fix client side block number calculations

### DIFF
--- a/garage/src/components/ProposalStatusBadge.tsx
+++ b/garage/src/components/ProposalStatusBadge.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useBlockNumber } from "wagmi";
 import { Badge } from "@chakra-ui/react";
 import { Proposal, ProposalStatus } from "~/types";
+import { secondaryChain } from "~/env";
 
 export const proposalStatus = (
   blockNumber: bigint | undefined,
@@ -17,7 +18,7 @@ export const proposalStatus = (
 };
 
 export const ProposalStatusBadge = ({ proposal }: { proposal: Proposal }) => {
-  const { data: blockNumber } = useBlockNumber();
+  const { data: blockNumber } = useBlockNumber({ chainId: secondaryChain.id });
   const status = proposalStatus(blockNumber, proposal);
 
   return (

--- a/garage/src/pages/Dashboard/modules/RigsInventory.tsx
+++ b/garage/src/pages/Dashboard/modules/RigsInventory.tsx
@@ -143,7 +143,7 @@ const isSelectable = (rig: Rig, selectable: Selectable): boolean => {
 export const RigsInventory = (props: React.ComponentProps<typeof Box>) => {
   const { actingAsAddress } = useAccount();
   const { rigs, refresh } = useOwnedRigs(actingAsAddress);
-  const { data: currentBlockNumber } = useBlockNumber();
+  const { data: currentBlockNumber } = useBlockNumber({ chainId: mainChain.id });
   const pilots = useMemo(() => {
     if (!rigs) return;
 

--- a/garage/src/pages/PilotDetails/index.tsx
+++ b/garage/src/pages/PilotDetails/index.tsx
@@ -228,7 +228,7 @@ export const PilotDetails = () => {
     return !!address && address.toLowerCase() === owner?.toLowerCase();
   }, [address, owner]);
 
-  const { data: currentBlockNumber } = useBlockNumber();
+  const { data: currentBlockNumber } = useBlockNumber({ chainId: mainChain.id });
 
   return (
     <Flex

--- a/garage/src/pages/Proposal/index.tsx
+++ b/garage/src/pages/Proposal/index.tsx
@@ -89,7 +89,7 @@ const CastVote = ({
 
   const { votingPower } = useAddressVotingPower(address, proposal.id);
 
-  const { data: blockNumber } = useBlockNumber();
+  const { data: blockNumber } = useBlockNumber({ chainId: secondaryChain.id });
   const [votes, setVotes] = useState<VoteState>({});
 
   const isEligible = (votingPower ?? 0) > 0;
@@ -468,7 +468,7 @@ const Votes = ({
 };
 
 const Results = ({ proposal, results, refresh, ...props }: ModuleProps) => {
-  const { data: blockNumber } = useBlockNumber();
+  const { data: blockNumber } = useBlockNumber({ chainId: secondaryChain.id });
 
   const totalResults = results.reduce((acc, { result }) => acc + result, 0);
 
@@ -572,8 +572,7 @@ const Header = ({ proposal, results, refresh, ...props }: ModuleProps) => {
 
 export const Proposal = () => {
   const { id } = useParams();
-
-  const { data: blockNumber } = useBlockNumber();
+  const { data: blockNumber } = useBlockNumber({ chainId: secondaryChain.id });
   const {
     data: { proposal, votes, results },
     refresh,

--- a/garage/src/pages/Proposals/index.tsx
+++ b/garage/src/pages/Proposals/index.tsx
@@ -19,6 +19,7 @@ import {
   proposalStatus,
   ProposalStatusBadge,
 } from "~/components/ProposalStatusBadge";
+import { secondaryChain } from "~/env";
 
 const GRID_GAP = 4;
 
@@ -34,12 +35,12 @@ type ModuleProps = React.ComponentProps<typeof Box> & {
 };
 
 const Information = ({ proposal, ...props }: ModuleProps) => {
-  const { data: blockNumber } = useBlockNumber();
+  const { data: blockNumber } = useBlockNumber({ chainId: secondaryChain.id });
 
-  const status = useMemo(() => proposalStatus(blockNumber, proposal), [
-    blockNumber,
-    proposal,
-  ]);
+  const status = useMemo(
+    () => proposalStatus(blockNumber, proposal),
+    [blockNumber, proposal]
+  );
 
   const startsIn = proposal.startBlock - Number(blockNumber ?? 0);
   const endsIn = proposal.endBlock - Number(blockNumber ?? 0);
@@ -110,9 +111,7 @@ export const Proposals = () => {
               {...MODULE_PROPS}
             />
           ))}
-        {proposals?.length === 0 && (
-          <Box {...MODULE_PROPS}>Coming soon.</Box>
-        )}
+        {proposals?.length === 0 && <Box {...MODULE_PROPS}>Coming soon.</Box>}
       </VStack>
     </Flex>
   );

--- a/garage/src/pages/RigDetails/index.tsx
+++ b/garage/src/pages/RigDetails/index.tsx
@@ -265,7 +265,9 @@ const FilecoinDealsModal = ({
 export const RigDetails = () => {
   const { id } = useParams();
   const { actingAsAddress } = useAccount();
-  const { data: currentBlockNumber } = useBlockNumber();
+  const { data: currentBlockNumber } = useBlockNumber({
+    chainId: mainChain.id,
+  });
   const { rig, refresh: refreshRig } = useRig(id || "");
 
   const { data: contractData, refetch } = useContractReads({

--- a/garage/src/pages/RigDetails/modules/Pilots.tsx
+++ b/garage/src/pages/RigDetails/modules/Pilots.tsx
@@ -88,7 +88,7 @@ export const Pilots = ({
   p,
   ...props
 }: PilotProps) => {
-  const { data: blockNumber, refetch } = useBlockNumber();
+  const { data: blockNumber, refetch } = useBlockNumber({ chainId: mainChain.id });
   useEffect(() => {
     refetch();
   }, [rig, refetch]);


### PR DESCRIPTION
the `useBlockNumber` hook defaults to using the currently connected chains block number but we always want a block number from a specific chain