### PR TITLE
Garage: Fix listing of owned NFTs when piloting a Rig

### DIFF
--- a/garage/src/hooks/useNFTs.ts
+++ b/garage/src/hooks/useNFTs.ts
@@ -127,7 +127,7 @@ const fetchNftsForOwner = async (
     pageSize,
     pageKey,
     omitMetadata: false,
-    excludeFilters: [NftFilters.SPAM, NftFilters.AIRDROPS],
+    excludeFilters: [NftFilters.SPAM],
   };
   if (filter?.contracts) {
     options = { ...options, contractAddresses: filter.contracts };


### PR DESCRIPTION
Removes the alchemy AIRDROPS filter from useOwnedNFTs, something muyt have changed in alchemy's api because this filter used to work well but now it filters out a lot of non-spam NFTs