### PR TITLE
fix: replace single quotes with '' value

### DIFF
--- a/garage/src/components/SubmitMissionModal.tsx
+++ b/garage/src/components/SubmitMissionModal.tsx
@@ -60,12 +60,15 @@ export const SubmitMissionModal = ({
     deliverables.length === mission.deliverables.length &&
     !deliverables.map(({ value }) => value).some(isEmpty);
 
+  const sanitizeDeliverables = deliverables.map(({ key, value }) => ({
+    [key]: value.replace(/\'/g, "''"),
+  }));
   const { config } = usePrepareContractWrite({
     chainId: secondaryChain.id,
     address: as0xString(missionContractAddress),
     abi,
     functionName: "submitMissionContribution",
-    args: [BigInt(mission.id), JSON.stringify(deliverables)],
+    args: [BigInt(mission.id), JSON.stringify(sanitizeDeliverables)],
     enabled: isOpen && isValid,
   });
 


### PR DESCRIPTION
## Summary

Fixes a bug where mission contributions had unescaped single quotes, leading to a query syntax error. This fix just replaces all solo single quotes with two single quotes.

## Details

Here's a tx that failed to the workd `they're`: https://tableland.network/api/v1/receipt/42161/0x879420e20419660251d60e31afa148f1bf61c6cdb0173104addde7dd99494871

The fix santizes the values before calling the smart contract:
```js
const sanitizeDeliverables = deliverables.map(({ key, value }) => ({
  [key]: value.replace(/\'/g, "''"),
}));
```

## How it was tested

Here's a testnet tx that succeeds with the fix & the word `they're` converted to `they''re`: https://mumbai.polygonscan.com/tx/0x4456d2f50ca1c83492ce1f6755389bf8d4224fc384a0638bee57460500b45d19